### PR TITLE
look ahead to include closing tags

### DIFF
--- a/webdiff/static/jsdifflib/diffview.js
+++ b/webdiff/static/jsdifflib/diffview.js
@@ -299,6 +299,13 @@ differ.htmlTextMapper.prototype.getHtmlSubstring = function(start, limit) {
     }
     htmlIndex += 1;
     textIndex += 1;
+    // include closing tags
+    if (htmlIndex + 1 <= html.length && html.charAt(htmlIndex) == '<' && html.charAt(htmlIndex + 1) == '/') {
+      while (html.charAt(htmlIndex) != '>') {
+        htmlIndex += 1;
+      }
+      htmlIndex += 1;
+    }
   };
 
   while (textIndex < start) {


### PR DESCRIPTION
I tried this on a change from
`chrome.runtime.sendMessage({ what:"label", stuff }, function() {`
to
`chrome.runtime.sendMessage({ what:"label"/*, stuff*/ }, function() {`

Using webdiff this displays as:
`chrome.runtime.sendMessage({ what:"label"pan class="hljs-comment">/*, stuff*/ }, function() {`

When stepping through the html and text in advanceOne() I think it should look ahead to include the closing hljs `</span>` tag. Otherwise the next time around will get out of sync and result in funky markup.
