### PR TITLE
cfg option for skipping browser open on reload

### DIFF
--- a/webdiff/app.py
+++ b/webdiff/app.py
@@ -174,7 +174,7 @@ def is_hot_reload():
 def open_browser():
     global PORT
     if not 'NO_OPEN_BROWSER' in app.config:
-        if is_hot_reload() and not 'BROWSER_OPEN_ON_RERUN' in app.config:
+        if is_hot_reload():
             log.debug('Skipping browser open on reload')
         else:
             webbrowser.open_new_tab('http://localhost:%s' % PORT)


### PR DESCRIPTION
Somewhat similar to existing `NO_OPEN_BROWSER` option, but I'm imagining a world where the tab is opened once when you run `webdiff`, but subsequent updates are inherited by that page, or can be picked up by refreshing it.

Basically, the reasonable numbers of tabs for one `webdiff` process to open are `0`, `1`, and "many", and this allows for the `1` option.
