### PR TITLE
Show perceptual diff boxes; update React, codediff.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
     "highlightjs": "~8.0.0",
     "underscore": "~1.6.0",
     "react": "~0.12.2",
-    "react-router": "~0.11.6"
+    "react-router": "~0.11.6",
+    "resemblejs": "danvk/Resemble.js#master"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "jquery": "~2.1.1",
     "highlightjs": "~8.0.0",
     "underscore": "~1.6.0",
-    "react": "~0.11.1",
-    "react-router": "~0.10.2"
+    "react": "~0.12.2",
+    "react-router": "~0.11.6"
   }
 }

--- a/tests/runner.html
+++ b/tests/runner.html
@@ -18,6 +18,7 @@
   <script src="../webdiff/static/components/react/react.js"></script>
   <script src="../webdiff/static/components/react/JSXTransformer.js"></script>
   <script src="../webdiff/static/components/react-router/dist/react-router.js"></script>
+  <script src="../webdiff/static/components/resemblejs/resemble.js"></script>
 
   <script src="../webdiff/static/codediff.js/difflib.js"></script>
   <script src="../webdiff/static/codediff.js/codediff.js"></script>

--- a/tests/travis-test.sh
+++ b/tests/travis-test.sh
@@ -3,4 +3,4 @@
 set -o errexit
 
 nosetests tests
-grunt test --verbose --force
+grunt test --verbose

--- a/webdiff/app.py
+++ b/webdiff/app.py
@@ -229,6 +229,8 @@ def run():
 
     A_DIR, B_DIR, DIFF = util.diff_for_args(parsed_args)
 
+    print 'DIFF:\n%r\n' % DIFF
+
     if app.config['TESTING'] or app.config['DEBUG']:
         sys.stderr.write('Diffing:\nA: %s\nB: %s\n\n' % (A_DIR, B_DIR))
 

--- a/webdiff/app.py
+++ b/webdiff/app.py
@@ -229,8 +229,6 @@ def run():
 
     A_DIR, B_DIR, DIFF = util.diff_for_args(parsed_args)
 
-    print 'DIFF:\n%r\n' % DIFF
-
     if app.config['TESTING'] or app.config['DEBUG']:
         sys.stderr.write('Diffing:\nA: %s\nB: %s\n\n' % (A_DIR, B_DIR))
 

--- a/webdiff/static/codediff.js/codediff.css
+++ b/webdiff/static/codediff.js/codediff.css
@@ -2,80 +2,64 @@
   box-sizing: border-box;
 }
 
-.diff-column-width {
-  max-width: 101ch;
-  min-width: 40ch;
+div.diff {
+  max-width: 100%;
+  display: table;
+}
+
+table.diff {
   width: 100%;
-}
-.diff-column {
-  max-width: 50%;
+  border-spacing: 0;
 }
 
-.diff-header, .line-no-header {
-  font-weight: bold;
-  border-bottom: 1px solid #ddd;
-  padding: 2px;
+td.code {
+  /* this is the max width of each column of code. */
+  /* for table cells, `width` behaves more like `max-width`. */
+  width: 61ch;
+  white-space: pre-wrap;
+  word-wrap: break-word;
 }
 
-.diff-line-no {
-  display: table;  /* shrink to fit longest line number */
-}
-.diff-left .diff-line-no {
-  float: left;
-}
-.diff-right .diff-line-no {
-  float: right;
-}
-.diff-remainder {
-  overflow: hidden;  /* see http://stackoverflow.com/questions/5540485/how-to-make-an-inline-block-element-fill-the-remainder-of-the-line */
+table.diff td {
+  vertical-align: top;
 }
 
+/* Line numbers with thin vertical bars to indicate wrapped lines. */
 .line-no {
   color: #999;
   background-color: #f7f7f7;
 }
+.line-no:first-child {
+  background-image:
+      linear-gradient(to left, #f7f7f7, #f7f7f7 3px, transparent, transparent 6px, #f7f7f7 6px),
+      linear-gradient(#f7f7f7, #f7f7f7 1.4em, #aaa 1.4em);
+}
+.line-no:last-child {
+  background-image:
+      linear-gradient(to right, #f7f7f7, #f7f7f7 3px, transparent, transparent 6px, #f7f7f7 6px),
+      linear-gradient(#f7f7f7, #f7f7f7 1.4em, #aaa 1.4em);
+}
 
-.diff-left .line-no {
+table.diff .line-no:first-child {
   border-right: 1px solid #ddd;
   text-align: right;
 }
-.diff-right .line-no {
+table.diff .line-no:last-child {
   border-left: 1px solid #ddd;
   text-align: left;
 }
-.diff-left.diff-column {
+table.diff td:nth-child(2) {
   border-right: 1px solid #ddd;
-}
-
-.diff-line-no, .diff-wrapper, .diff-column {
-  display: inline-block;
-  vertical-align: top;
-}
-
-.diff-wrapper {
-  overflow-x: auto;
-  overflow-y: hidden;  /* shouldn't happen, but we sometimes get a pixel. */
-}
-
-.diff-content {
-  display: table;  /* "expand to fit" */
-  min-width: 100%;
 }
 
 .line-no, .code {
   padding: 2px;
   height: 1.11em;
-  white-space: pre;
   font-family: monospace;
 }
-
-.diff {
-  white-space: nowrap;
-}
-
-.diff-wrapper, .diff-wrapper > div {
-  display: inline-block;
-  vertical-align: top;
+.diff .skip {
+  text-align: center;
+  background: #f7f7f7;
 }
 
 .diff .delete {
@@ -85,17 +69,63 @@
   background-color: #efe;
 }
 
-.diff-left-content .replace {
+.before.replace {
   background-color: #fee;
 }
-.diff-right-content .replace {
+.after.replace {
   background-color: #efe;
 }
 
-.diff-left-content .char-replace, .diff-left-content .char-delete {
+.before .char-replace, .before .char-delete {
   background-color: #fcc;
 }
 
-.diff-right-content .char-replace, .diff-right-content .char-insert {
+.after .char-replace, .after .char-insert {
   background-color: #cfc;
+}
+
+/* Single column selection */
+.selecting-left  td,
+.selecting-left  td *,
+.selecting-right td,
+.selecting-right td *
+{
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.selecting-left  td.line-no::selection,
+.selecting-left  td.line-no *::selection,
+.selecting-right td.line-no::selection,
+.selecting-right td.line-no *::selection,
+.selecting-left  td.after::selection,
+.selecting-left  td.after *::selection,
+.selecting-right td.before::selection,
+.selecting-right td.before *::selection
+{
+  background: transparent;
+}
+
+.selecting-left  td.line-no::-moz-selection,
+.selecting-left  td.line-no *::-moz-selection,
+.selecting-right td.line-no::-moz-selection,
+.selecting-right td.line-no *::-moz-selection,
+.selecting-left  td.after::-moz-selection,
+.selecting-left  td.after *::-moz-selection,
+.selecting-right td.before::-moz-selection,
+.selecting-right td.before *::-moz-selection
+{
+  background: transparent;
+}
+
+.selecting-left  td.before,
+.selecting-left  td.before *,
+.selecting-right td.after,
+.selecting-right td.after * {
+  -moz-user-select: text;
+  -webkit-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
 }

--- a/webdiff/static/css/style.css
+++ b/webdiff/static/css/style.css
@@ -109,6 +109,10 @@ ul.file-list {
 .swipe input {
   width: 100%;
 }
+.onion-skin .range-holder {
+  margin: 0 auto;  /* center the slider */
+  display: table;
+}
 .onion-skin input {
   width: 200px;
 }
@@ -139,5 +143,10 @@ table .side-a, table .side-b {
 }
 .perceptual-diff {
   position: absolute;
-  border: 2px solid red;
+  border: 2px solid hotpink;
+  box-shadow: 0 0 5px 0 rgba(50, 50, 50, 0.75);
+}
+
+.diff-box-disabled {
+  color: gray;
 }

--- a/webdiff/static/css/style.css
+++ b/webdiff/static/css/style.css
@@ -133,3 +133,7 @@ table .side-a, table .side-b {
 .image-diff .no-changes {
   margin-top: 10px;
 }
+
+.perceptual-diff {
+  position: absolute;
+}

--- a/webdiff/static/css/style.css
+++ b/webdiff/static/css/style.css
@@ -134,6 +134,10 @@ table .side-a, table .side-b {
   margin-top: 10px;
 }
 
+.image-holder {
+  position: relative;  /* offset parent for .perceptual-diff */
+}
 .perceptual-diff {
   position: absolute;
+  border: 2px solid red;
 }

--- a/webdiff/static/css/style.css
+++ b/webdiff/static/css/style.css
@@ -8,9 +8,8 @@ div#thediff {
     font-size: 13px;
 }
 
-.diff-column-width {
-    max-width: 101ch; /* 80ch for code, plus some extra wiggle room */
-    min-width: 50ch;
+td.code {
+  width: 81ch;
 }
 
 .file-selector {

--- a/webdiff/static/js/components.jsx
+++ b/webdiff/static/js/components.jsx
@@ -375,7 +375,7 @@ var AnnotatedImage = React.createClass({
     var im = this.props.filePair['image_' + side];
     return (
       <div className={'image-' + side}>
-        <Image filePair={this.props.filePair} side={side} maxWidth={this.props.maxWidth} />
+        <SingleImage filePair={this.props.filePair} side={side} maxWidth={this.props.maxWidth} />
         <ImageMetadata image={im} />
       </div>
     );
@@ -383,7 +383,7 @@ var AnnotatedImage = React.createClass({
 });
 
 
-var Image = React.createClass({
+var SingleImage = React.createClass({
   propTypes: {
     filePair: React.PropTypes.object.isRequired,
     side: React.PropTypes.oneOf(['a', 'b']).isRequired,
@@ -424,19 +424,45 @@ var ImageMetadata = React.createClass({
 });
 
 
+// Global Resemble.js config.
+resemble.outputSettings({
+  errorColor: {
+    red: 255,
+    green: 0,
+    blue: 0
+  },
+  errorType: 'movement',
+  transparency: 0.3
+});
+
+
 // Two images placed side-by-side.
 var ImageSideBySide = React.createClass({
   propTypes: {
     filePair: React.PropTypes.object.isRequired,
     shrinkToFit: React.PropTypes.bool
   },
+  renderDiff: function() {
+    resemble('/b/image/' + this.props.filePair.a)
+        .compareTo('/a/image/' + this.props.filePair.b)
+        .onComplete(function(data) {
+          var diffImage = new Image();
+          diffImage.src = data.getImageDataUrl();
+          $('#image-diff-differences').html(diffImage);
+        })
+  },
   render: function() {
     var pair = this.props.filePair;
     var maxWidth = this.props.shrinkToFit ? (window.innerWidth - 30) / 2 : null;
+    this.renderDiff();
     return <table id="imagediff">
       <tr className="image-diff-content">
         <td className="diff-left"><AnnotatedImage filePair={pair} side="a" maxWidth={maxWidth} /></td>
         <td className="diff-right"><AnnotatedImage filePair={pair} side="b" maxWidth={maxWidth} /></td>
+      </tr>
+      <tr>
+        <td colSpan="2" id="image-diff-differences">
+        </td>
       </tr>
     </table>;
   }

--- a/webdiff/static/js/util.js
+++ b/webdiff/static/js/util.js
@@ -61,3 +61,41 @@ var SetIntervalMixin = {
     this.intervals.map(clearInterval);
   }
 };
+
+
+// Global Resemble.js config.
+resemble.outputSettings({
+  errorColor: {
+    red: 255,
+    green: 0,
+    blue: 0
+  },
+  errorType: 'movement',
+  transparency: 0.3
+});
+
+// Compute a perceptual diff using Resemble.js.
+// This memoizes the diff to facilitate working with React.
+// Returns deferred Resemble diff data.
+function computePerceptualDiff(fileA, fileB) {
+  if (!resemble.cache) resemble.cache = {};
+
+  return new Promise(function(resolve, reject) {
+    var key = [fileA, fileB].join(':');
+    var v = resemble.cache[key];
+    if (v) {
+      resolve(v);
+    } else {
+      resemble(fileB).compareTo(fileA).onComplete(function(data) {
+        resemble.cache[key] = data;
+        resolve(data);
+      });
+    }
+  });
+}
+
+function makeImage(dataURI) {
+  var img = new Image();
+  img.src = dataURI;
+  return img;
+}

--- a/webdiff/static/js/util.js
+++ b/webdiff/static/js/util.js
@@ -49,6 +49,19 @@ function isOneSided(filePair) {
 }
 
 
+/**
+ * Determines whether the before & after images are the same size.
+ */
+function isSameSizeImagePair(filePair) {
+  if (!filePair.is_image_diff) return false;
+  if (isOneSided(filePair)) return false;
+  if (!filePair.a || !filePair.b) return false;
+  var imA = filePair.image_a,
+      imB = filePair.image_b;
+  return (imA.width == imB.width && imA.height == imB.height);
+}
+
+
 // From http://facebook.github.io/react/docs/reusable-components.html
 var SetIntervalMixin = {
   componentWillMount: function() {

--- a/webdiff/static/js/util.js
+++ b/webdiff/static/js/util.js
@@ -71,7 +71,8 @@ resemble.outputSettings({
     blue: 0
   },
   errorType: 'movement',
-  transparency: 0.3
+  transparency: 0.0,  // don't include any of the original image.
+  ignoreAntialiasing: true
 });
 
 // Compute a perceptual diff using Resemble.js.

--- a/webdiff/templates/base.html
+++ b/webdiff/templates/base.html
@@ -12,6 +12,7 @@
   <script src="/static/components/react/react.js"></script>
   <script src="/static/components/react/JSXTransformer.js"></script>
   <script src="/static/components/react-router/dist/react-router.js"></script>
+  <script src="/static/components/resemblejs/resemble.js"></script>
 
   <script src="/static/codediff.js/difflib.js"></script>
   <script src="/static/codediff.js/codediff.js"></script>

--- a/webdiff/templates/file_diff.html
+++ b/webdiff/templates/file_diff.html
@@ -26,21 +26,19 @@ var Routes = ReactRouter.Routes;
 
 var App = React.createClass({
   render: function() {
-    return this.props.activeRouteHandler();
+    return <ReactRouter.RouteHandler />;
   }
 });
 
 var routes = (
-  <Routes location="history">
-    <Route handler={App}>
-      <Route name="pair" path="/:index?" handler={Root}
-             filePairs={pairs}
-             initiallySelectedIndex={initialIdx} />
-    </Route>
-  </Routes>
+  <Route handler={App}>
+    <Route name="pair" path="/:index?" handler={makeRoot(pairs, initialIdx)} />
+  </Route>
 );
 
-React.renderComponent(routes, $('#application').get(0));
+ReactRouter.run(routes, ReactRouter.HistoryLocation, function(Handler) {
+  React.render(<Handler/>, $('#application').get(0));
+});
 </script>
 
 <script>

--- a/webdiff/util.py
+++ b/webdiff/util.py
@@ -196,7 +196,21 @@ def _shim_for_file_diff(a_file, b_file):
 
 
 def diff_for_args(args):
-    """Returns A_DIR, B_DIR, find_diff() for parsed command line args."""
+    """Returns A_DIR, B_DIR, find_diff() for parsed command line args.
+    
+    DIFF looks something like:
+    [ {
+        'a': '1_normal.jpg',
+        'is_image_diff': True,
+        'b': '1_normal.jpg',
+        'idx': 0,
+        'no_changes': False,
+        'image_a': {'width': 300, 'num_bytes': 20831, 'height': 300},
+        'image_b': {'width': 300, 'num_bytes': 20713, 'height': 300},
+        'path': '1_normal.jpg',
+        'type': 'change'
+      }, ... ]
+    """
     if 'dirs' in args:
         return list(args['dirs']) + [find_diff(*args['dirs'])]
 


### PR DESCRIPTION
See #75 

Highlights:
- Updates React to 0.12, react-router to 0.11
- Updates codediff.js to get the new table-based layout and `minJumpSize`, which suppresses elision of small #s of lines.
- Adds an option to outline the areas of images that have changed, so long as the before/after are the same size. This is done via a [modified][1] version of resemble.js.

See [video](http://cl.ly/0p021Z381U3u) screengrab.

[1]: https://github.com/Huddle/Resemble.js/pull/34