### PR TITLE
Show perceptual diffs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,6 @@
     "highlightjs": "~8.0.0",
     "underscore": "~1.6.0",
     "react": "~0.12.2",
-    "react-router": "~0.11.6",
-    "resemblejs": "1.2.1"
+    "react-router": "~0.11.6"
   }
 }

--- a/tests/pair_test.py
+++ b/tests/pair_test.py
@@ -38,14 +38,18 @@ def test_pairing_with_move():
     testdir = 'testdata/renamedfile'
     diff = util.find_diff('%s/left/dir' % testdir, '%s/right/dir' % testdir)
     eq_([{'a': 'file.json',
+          'a_path': 'testdata/renamedfile/left/dir/file.json',
           'path': 'file.json',
           'b': 'renamed.json',
+          'b_path': 'testdata/renamedfile/right/dir/renamed.json',
           'type': 'move',
           'no_changes': True,
           'idx': 0},
          {'a': 'file.json',
+          'a_path': 'testdata/renamedfile/left/dir/file.json',
           'path': 'file.json',
           'b': None,
+          'b_path': None,
           'type': 'delete',
           'no_changes': False,
           'idx': 1}], diff)

--- a/tests/runner.html
+++ b/tests/runner.html
@@ -18,7 +18,6 @@
   <script src="../webdiff/static/components/react/react.js"></script>
   <script src="../webdiff/static/components/react/JSXTransformer.js"></script>
   <script src="../webdiff/static/components/react-router/dist/react-router.js"></script>
-  <script src="../webdiff/static/components/resemblejs/resemble.js"></script>
 
   <script src="../webdiff/static/codediff.js/difflib.js"></script>
   <script src="../webdiff/static/codediff.js/codediff.js"></script>

--- a/webdiff/app.py
+++ b/webdiff/app.py
@@ -14,7 +14,7 @@ from threading import Timer
 import time
 import webbrowser
 
-from flask import (Flask, render_template, send_from_directory,
+from flask import (Flask, render_template, send_from_directory, send_file,
                    request, jsonify, Response)
 
 import util
@@ -134,6 +134,15 @@ def get_image(side, path):
         response = jsonify(e)
         response.status_code = 400
         return response
+
+
+@app.route("/imagediff/<int:idx>")
+def get_image_diff(idx):
+    idx = int(idx)
+    pair = DIFF[idx]
+    _, pdiff_image = util.generate_pdiff_image(pair['a_path'], pair['b_path'])
+    dilated_image = util.generate_dilated_pdiff_image(pdiff_image)
+    return send_file(dilated_image)
 
 
 # Show the first diff by default

--- a/webdiff/app.py
+++ b/webdiff/app.py
@@ -136,13 +136,22 @@ def get_image(side, path):
         return response
 
 
-@app.route("/imagediff/<int:idx>")
-def get_image_diff(idx):
+@app.route("/pdiff/<int:idx>")
+def get_pdiff(idx):
     idx = int(idx)
     pair = DIFF[idx]
     _, pdiff_image = util.generate_pdiff_image(pair['a_path'], pair['b_path'])
     dilated_image = util.generate_dilated_pdiff_image(pdiff_image)
     return send_file(dilated_image)
+
+
+@app.route("/pdiffbbox/<int:idx>")
+def get_pdiff_bbox(idx):
+    idx = int(idx)
+    pair = DIFF[idx]
+    _, pdiff_image = util.generate_pdiff_image(pair['a_path'], pair['b_path'])
+    bbox = util.get_pdiff_bbox(pdiff_image)
+    return jsonify(bbox)
 
 
 # Show the first diff by default

--- a/webdiff/app.py
+++ b/webdiff/app.py
@@ -140,8 +140,13 @@ def get_image(side, path):
 def get_pdiff(idx):
     idx = int(idx)
     pair = DIFF[idx]
-    _, pdiff_image = util.generate_pdiff_image(pair['a_path'], pair['b_path'])
-    dilated_image = util.generate_dilated_pdiff_image(pdiff_image)
+    try:
+        _, pdiff_image = util.generate_pdiff_image(pair['a_path'], pair['b_path'])
+        dilated_image = util.generate_dilated_pdiff_image(pdiff_image)
+    except util.ImageMagickNotAvailableError:
+        return 'ImageMagick is not available', 501
+    except util.ImageMagickError as e:
+        return 'ImageMagick error %s' % e, 501
     return send_file(dilated_image)
 
 
@@ -149,8 +154,13 @@ def get_pdiff(idx):
 def get_pdiff_bbox(idx):
     idx = int(idx)
     pair = DIFF[idx]
-    _, pdiff_image = util.generate_pdiff_image(pair['a_path'], pair['b_path'])
-    bbox = util.get_pdiff_bbox(pdiff_image)
+    try:
+        _, pdiff_image = util.generate_pdiff_image(pair['a_path'], pair['b_path'])
+        bbox = util.get_pdiff_bbox(pdiff_image)
+    except util.ImageMagickNotAvailableError:
+        return 'ImageMagick is not available', 501
+    except util.ImageMagickError as e:
+        return 'ImageMagick error %s' % e, 501
     return jsonify(bbox)
 
 
@@ -165,6 +175,7 @@ def file_diff(idx):
     idx = int(idx)
     return render_template('file_diff.html',
                            idx=idx,
+                           has_magick=util.is_imagemagick_available(),
                            pairs=DIFF)
 
 

--- a/webdiff/static/css/style.css
+++ b/webdiff/static/css/style.css
@@ -142,8 +142,13 @@ table .side-a, table .side-b {
 }
 .perceptual-diff {
   position: absolute;
+}
+.perceptual-diff.bbox {
   border: 2px solid hotpink;
   box-shadow: 0 0 5px 0 rgba(50, 50, 50, 0.75);
+}
+.perceptual-diff.pixels {
+  opacity: 0.5;
 }
 
 .diff-box-disabled {

--- a/webdiff/static/css/style.css
+++ b/webdiff/static/css/style.css
@@ -154,3 +154,9 @@ table .side-a, table .side-b {
 .diff-box-disabled {
   color: gray;
 }
+.pdiff-options {
+  margin-left: 10px;
+}
+.magick {
+  font-style: italic;
+}

--- a/webdiff/static/js/components.jsx
+++ b/webdiff/static/js/components.jsx
@@ -258,8 +258,11 @@ var NoChanges = React.createClass({
     filePair: React.PropTypes.object.isRequired
   },
   render: function() {
-    if (this.props.filePair.no_changes) {
-      return <div className="no-changes">(No Changes)</div>;
+    var fp = this.props.filePair;
+    if (fp.no_changes) {
+      return <div className="no-changes">(File content is identical)</div>;
+    } else if (fp.is_image_diff && fp.are_same_pixels) {
+      return <div className="no-changes">Pixels are the same, though file content differs (perhaps the headers are different?)</div>;
     } else {
       return null;
     }

--- a/webdiff/static/js/components.jsx
+++ b/webdiff/static/js/components.jsx
@@ -36,20 +36,24 @@ var makeRoot = function(filePairs, initiallySelectedIndex) {
     },
     computePerceptualDiff: function() {
       var fp = this.props.filePairs[this.getIndex()];
-      computePerceptualDiff('/a/image/' + fp.a, '/b/image/' + fp.b)
-        .then((diffData) => {
-          fp.diffData = diffData;
-          this.forceUpdate();  // tell react about this change
-        })
-        .catch(function(reason) {
-          console.error(reason);
-        });
+      if (!fp.is_image_diff) return;
+      fp.diffData = {
+        isSameDimensions: isSameSizeImagePair(fp)
+      };
+      $.getJSON(`/pdiffbbox/${this.getIndex()}`)
+          .done(bbox => {
+            fp.diffData.diffBounds = bbox;
+            this.forceUpdate();  // tell react about this change
+          }).fail(error => {
+            console.error(error);
+          });
     },
     render: function() {
       var idx = this.getIndex(),
           filePair = this.props.filePairs[idx];
 
       if (this.state.showPerceptualDiffBox && !filePair.diffData) {
+        // XXX this might shoot off unnecessary XHRs--use a Promise!
         this.computePerceptualDiff();
       }
 

--- a/webdiff/static/js/components.jsx
+++ b/webdiff/static/js/components.jsx
@@ -4,6 +4,13 @@
  */
 'use strict';
 
+// Perceptual diffing mode
+var PDIFF_MODE = {
+  OFF: 0,
+  BBOX: 1,
+  PIXELS: 2
+};
+
 // Webdiff application root.
 var makeRoot = function(filePairs, initiallySelectedIndex) {
   return React.createClass({
@@ -15,7 +22,7 @@ var makeRoot = function(filePairs, initiallySelectedIndex) {
     mixins: [ReactRouter.Navigation, ReactRouter.State],
     getInitialState: () => ({
       imageDiffMode: 'side-by-side',
-      showPerceptualDiffBox: false
+      pdiffMode: PDIFF_MODE.OFF
     }),
     getDefaultProps: function() {
       return {filePairs, initiallySelectedIndex};
@@ -31,17 +38,15 @@ var makeRoot = function(filePairs, initiallySelectedIndex) {
     changeImageDiffModeHandler: function(mode) {
       this.setState({imageDiffMode: mode});
     },
-    changeShowPerceptualDiffBox: function(shouldShow) {
-      this.setState({showPerceptualDiffBox: shouldShow});
+    changePdiffMode: function(pdiffMode) {
+      this.setState({pdiffMode});
     },
-    computePerceptualDiff: function() {
+    computePerceptualDiffBox: function() {
       var fp = this.props.filePairs[this.getIndex()];
-      if (!fp.is_image_diff) return;
-      fp.diffData = {
-        isSameDimensions: isSameSizeImagePair(fp)
-      };
+      if (!fp.is_image_diff || !isSameSizeImagePair(fp)) return;
       $.getJSON(`/pdiffbbox/${this.getIndex()}`)
           .done(bbox => {
+            if (!fp.diffData) fp.diffData = {};
             fp.diffData.diffBounds = bbox;
             this.forceUpdate();  // tell react about this change
           }).fail(error => {
@@ -52,9 +57,9 @@ var makeRoot = function(filePairs, initiallySelectedIndex) {
       var idx = this.getIndex(),
           filePair = this.props.filePairs[idx];
 
-      if (this.state.showPerceptualDiffBox && !filePair.diffData) {
+      if (this.state.pdiffMode == PDIFF_MODE.BBOX && !filePair.diffData) {
         // XXX this might shoot off unnecessary XHRs--use a Promise!
-        this.computePerceptualDiff();
+        this.computePerceptualDiffBox();
       }
 
       return (
@@ -64,9 +69,9 @@ var makeRoot = function(filePairs, initiallySelectedIndex) {
                         fileChangeHandler={this.selectIndex} />
           <DiffView filePair={filePair}
                     imageDiffMode={this.state.imageDiffMode}
-                    showPerceptualDiffBox={this.state.showPerceptualDiffBox}
+                    pdiffMode={this.state.pdiffMode}
                     changeImageDiffModeHandler={this.changeImageDiffModeHandler}
-                    changeShowPerceptualDiffBox={this.changeShowPerceptualDiffBox} />
+                    changePdiffMode={this.changePdiffMode} />
         </div>
       );
     },
@@ -88,7 +93,7 @@ var makeRoot = function(filePairs, initiallySelectedIndex) {
           this.setState({imageDiffMode: 'blink'});
         } else if (e.keyCode == 80) {  // p
           this.setState({
-            showPerceptualDiffBox: !this.state.showPerceptualDiffBox
+            pdiffMode: (this.state.pdiffMode + 1) % 3
           });
         }
       });
@@ -234,9 +239,9 @@ var DiffView = React.createClass({
   propTypes: {
     filePair: React.PropTypes.object.isRequired,
     imageDiffMode: React.PropTypes.oneOf(IMAGE_DIFF_MODES).isRequired,
-    showPerceptualDiffBox: React.PropTypes.bool,
+    pdiffMode: React.PropTypes.number,
     changeImageDiffModeHandler: React.PropTypes.func.isRequired,
-    changeShowPerceptualDiffBox: React.PropTypes.func.isRequired
+    changePdiffMode: React.PropTypes.func.isRequired
   },
   render: function() {
     if (this.props.filePair.is_image_diff) {

--- a/webdiff/static/js/image.jsx
+++ b/webdiff/static/js/image.jsx
@@ -49,9 +49,9 @@ var ImageDiff = React.createClass({
   propTypes: {
     filePair: React.PropTypes.object.isRequired,
     imageDiffMode: React.PropTypes.oneOf(IMAGE_DIFF_MODES).isRequired,
-    showPerceptualDiffBox: React.PropTypes.bool,
+    pdiffMode: React.PropTypes.number,
     changeImageDiffModeHandler: React.PropTypes.func.isRequired,
-    changeShowPerceptualDiffBox: React.PropTypes.func.isRequired
+    changePdiffMode: React.PropTypes.func.isRequired
   },
   getInitialState: function() {
     return {shrinkToFit: true};
@@ -59,8 +59,8 @@ var ImageDiff = React.createClass({
   toggleShrinkToFit: function(e) {
     this.setState({shrinkToFit: e.target.checked});
   },
-  toggleDiffBox: function(e) {
-    this.props.changeShowPerceptualDiffBox(e.target.checked);
+  setPdiffMode: function(mode) {
+    this.props.changePdiffMode(mode);
   },
   componentDidMount: function() {
     $(window).on('resize.shrink-to-fit', () => {
@@ -85,7 +85,7 @@ var ImageDiff = React.createClass({
     var image = React.createElement(component, {
       filePair: pair,
       shrinkToFit: this.state.shrinkToFit,
-      showPerceptualDiffBox: this.props.showPerceptualDiffBox
+      pdiffMode: this.props.pdiffMode
     });
     var diffBoxEnabled = isSameSizeImagePair(pair);
     var boxClasses = diffBoxEnabled ? '' : 'diff-box-disabled';
@@ -97,11 +97,25 @@ var ImageDiff = React.createClass({
         <label htmlFor="shrink-to-fit"> Shrink to fit</label>
         &nbsp;
         <span className={boxClasses}>
-          <input type="checkbox" id="show-diff-box"
-                 checked={this.props.showPerceptualDiffBox}
+          Perceptual Diff:
+          <input type="radio" name="pdiff-mode"
+                 id="pdiff-off"
+                 checked={this.props.pdiffMode == PDIFF_MODE.OFF}
                  disabled={!diffBoxEnabled}
-                 onChange={this.toggleDiffBox} />
-          <label htmlFor="show-diff-box"> Show diff box (p)</label>
+                 onChange={() => this.setPdiffMode(PDIFF_MODE.OFF)} />
+          <label htmlFor="pdiff-off"> None</label>
+          <input type="radio" name="pdiff-mode"
+                 id="pdiff-bbox"
+                 checked={this.props.pdiffMode == PDIFF_MODE.BBOX}
+                 disabled={!diffBoxEnabled}
+                 onChange={() => this.setPdiffMode(PDIFF_MODE.BBOX)} />
+          <label htmlFor="pdiff-bbox"> Box</label>
+          <input type="radio" name="pdiff-mode"
+                 id="pdiff-pixels"
+                 checked={this.props.pdiffMode == PDIFF_MODE.PIXELS}
+                 disabled={!diffBoxEnabled}
+                 onChange={() => this.setPdiffMode(PDIFF_MODE.PIXELS)} />
+          <label htmlFor="pdiff-pixels"> Differing Pixels</label>
         </span>
       </div>
       <div className={'image-diff ' + mode}>
@@ -117,21 +131,37 @@ var ImageDiff = React.createClass({
  * Returns a React.DIV which boxes the changed parts of the image pair.
  * scaleDown is in [0, 1], with 1 being full-size
  */
-function makePerceptualBoxDiv(filePair, scaleDown) {
-  var padding = 5;  // try not to obscure anything inside the box
-  if (filePair.diffData &&
-      filePair.diffData.isSameDimensions &&
-      filePair.diffData.diffBounds) {
-    var bbox = filePair.diffData.diffBounds;
-    var styles = {
-      top: Math.floor(scaleDown * (bbox.top - padding)) + 'px',
-      left: Math.floor(scaleDown * (bbox.left - padding)) + 'px',
-      width: Math.ceil(scaleDown * (bbox.right - bbox.left + 2 * padding)) + 'px',
-      height: Math.ceil(scaleDown * (bbox.bottom - bbox.top + 2 * padding)) + 'px'
-    };
-    return <div className='perceptual-diff' style={styles} />;
-  } else {
+function makePerceptualBoxDiv(pdiffMode, filePair, scaleDown) {
+  if (pdiffMode == PDIFF_MODE.OFF ||
+      !isSameSizeImagePair(filePair)) {
     return null;
+  } else if (pdiffMode == PDIFF_MODE.BBOX) {
+    var padding = 5;  // try not to obscure anything inside the box
+    if (filePair.diffData &&
+        filePair.diffData.diffBounds) {
+      var bbox = filePair.diffData.diffBounds;
+      var styles = {
+        top: Math.floor(scaleDown * (bbox.top - padding)) + 'px',
+        left: Math.floor(scaleDown * (bbox.left - padding)) + 'px',
+        width: Math.ceil(scaleDown * (bbox.right - bbox.left + 2 * padding)) + 'px',
+        height: Math.ceil(scaleDown * (bbox.bottom - bbox.top + 2 * padding)) + 'px'
+      };
+      return <div className='perceptual-diff bbox' style={styles} />;
+    } else {
+      return null;
+    }
+  } else if (pdiffMode == PDIFF_MODE.PIXELS) {
+    var styles = {top: 0, left: 0},
+        width = filePair.image_a.width * scaleDown,
+        height = filePair.image_a.height * scaleDown,
+        src = `/pdiff/${filePair.idx}`;
+    return (
+        <img className='perceptual-diff pixels'
+             style={styles}
+             width={width}
+             height={height}
+             src={src} />
+    );
   }
 }
 
@@ -141,7 +171,7 @@ var AnnotatedImage = React.createClass({
     filePair: React.PropTypes.object.isRequired,
     side: React.PropTypes.oneOf(['a', 'b']).isRequired,
     maxWidth: React.PropTypes.number,
-    showPerceptualDiffBox: React.PropTypes.bool
+    pdiffMode: React.PropTypes.number
   },
   render: function() {
     var side = this.props.side;
@@ -165,7 +195,7 @@ var SingleImage = React.createClass({
     filePair: React.PropTypes.object.isRequired,
     side: React.PropTypes.oneOf(['a', 'b']).isRequired,
     maxWidth: React.PropTypes.number,
-    showPerceptualDiffBox: React.PropTypes.bool
+    pdiffMode: React.PropTypes.number
   },
   render: function() {
     var filePair = this.props.filePair;
@@ -183,8 +213,7 @@ var SingleImage = React.createClass({
       im.width *= scaleDown;
       im.height *= scaleDown;
     }
-    var diffBoxDiv = this.props.showPerceptualDiffBox ?
-        makePerceptualBoxDiv(filePair, scaleDown) : null;
+    var diffBoxDiv = makePerceptualBoxDiv(this.props.pdiffMode, filePair, scaleDown);
 
     return (
       <div className='image-holder'>
@@ -218,9 +247,7 @@ var ImageSideBySide = React.createClass({
   propTypes: {
     filePair: React.PropTypes.object.isRequired,
     shrinkToFit: React.PropTypes.bool,
-    showPerceptualDiffBox: React.PropTypes.bool
-  },
-  renderDiff: function() {
+    pdiffMode: React.PropTypes.number
   },
   render: function() {
     var maxWidth = this.props.shrinkToFit ? (window.innerWidth - 30) / 2 : null;
@@ -345,8 +372,7 @@ var ImageSwipe = React.createClass({
       imB.height *= scaleDown;
       containerWidth = Math.max(imA.width, imB.width);
     }
-    var diffBoxDiv = this.props.showPerceptualDiffBox ?
-        makePerceptualBoxDiv(pair, scaleDown) : null;
+    var diffBoxDiv = makePerceptualBoxDiv(this.props.pdiffMode, pair, scaleDown);
     var styleA = {}, styleB = {}, styleContainer = {
       width: containerWidth + 'px',
       height: Math.max(imA.height, imB.height) + 'px'

--- a/webdiff/static/js/image.jsx
+++ b/webdiff/static/js/image.jsx
@@ -89,6 +89,12 @@ var ImageDiff = React.createClass({
     });
     var diffBoxEnabled = isSameSizeImagePair(pair);
     var boxClasses = diffBoxEnabled ? '' : 'diff-box-disabled';
+    var boxStyles = { display: HAS_IMAGE_MAGICK ? '' : 'none' };
+    var imageMagickCallout = !HAS_IMAGE_MAGICK ? (
+        <span className="magick">Install{' '}
+        <a href="http://www.imagemagick.org/script/binary-releases.php">ImageMagick</a>{' '}
+        to see perceptual diffs</span>
+    ) : null;
 
     return <div>
       <div className="image-diff-controls">
@@ -96,26 +102,31 @@ var ImageDiff = React.createClass({
         <input type="checkbox" id="shrink-to-fit" checked={this.state.shrinkToFit} onChange={this.toggleShrinkToFit} />
         <label htmlFor="shrink-to-fit"> Shrink to fit</label>
         &nbsp;
-        <span className={boxClasses}>
-          Perceptual Diff:
-          <input type="radio" name="pdiff-mode"
-                 id="pdiff-off"
-                 checked={this.props.pdiffMode == PDIFF_MODE.OFF}
-                 disabled={!diffBoxEnabled}
-                 onChange={() => this.setPdiffMode(PDIFF_MODE.OFF)} />
-          <label htmlFor="pdiff-off"> None</label>
-          <input type="radio" name="pdiff-mode"
-                 id="pdiff-bbox"
-                 checked={this.props.pdiffMode == PDIFF_MODE.BBOX}
-                 disabled={!diffBoxEnabled}
-                 onChange={() => this.setPdiffMode(PDIFF_MODE.BBOX)} />
-          <label htmlFor="pdiff-bbox"> Box</label>
-          <input type="radio" name="pdiff-mode"
-                 id="pdiff-pixels"
-                 checked={this.props.pdiffMode == PDIFF_MODE.PIXELS}
-                 disabled={!diffBoxEnabled}
-                 onChange={() => this.setPdiffMode(PDIFF_MODE.PIXELS)} />
-          <label htmlFor="pdiff-pixels"> Differing Pixels</label>
+        <span className="pdiff-options">
+          <span className={boxClasses} style={boxStyles}>
+            Perceptual Diff:&nbsp;
+            <input type="radio" name="pdiff-mode"
+                   id="pdiff-off"
+                   checked={this.props.pdiffMode == PDIFF_MODE.OFF}
+                   disabled={!diffBoxEnabled}
+                   onChange={() => this.setPdiffMode(PDIFF_MODE.OFF)} />
+            <label htmlFor="pdiff-off"> None</label>
+            &nbsp;
+            <input type="radio" name="pdiff-mode"
+                   id="pdiff-bbox"
+                   checked={this.props.pdiffMode == PDIFF_MODE.BBOX}
+                   disabled={!diffBoxEnabled}
+                   onChange={() => this.setPdiffMode(PDIFF_MODE.BBOX)} />
+            <label htmlFor="pdiff-bbox"> Box</label>
+            &nbsp;
+            <input type="radio" name="pdiff-mode"
+                   id="pdiff-pixels"
+                   checked={this.props.pdiffMode == PDIFF_MODE.PIXELS}
+                   disabled={!diffBoxEnabled}
+                   onChange={() => this.setPdiffMode(PDIFF_MODE.PIXELS)} />
+            <label htmlFor="pdiff-pixels"> Differing Pixels</label>
+          </span>
+          {imageMagickCallout}
         </span>
       </div>
       <div className={'image-diff ' + mode}>

--- a/webdiff/static/js/image.jsx
+++ b/webdiff/static/js/image.jsx
@@ -140,6 +140,7 @@ function makePerceptualBoxDiv(pdiffMode, filePair, scaleDown) {
     if (filePair.diffData &&
         filePair.diffData.diffBounds) {
       var bbox = filePair.diffData.diffBounds;
+      if (bbox.width == 0 || bbox.height == 0) return null;
       var styles = {
         top: Math.floor(scaleDown * (bbox.top - padding)) + 'px',
         left: Math.floor(scaleDown * (bbox.left - padding)) + 'px',
@@ -432,5 +433,19 @@ var ImageSwipe = React.createClass({
         </div>
       </div>
     );
+  }
+});
+
+
+var NoPixelsChanged = React.createClass({
+  propTypes: {
+    filePair: React.PropTypes.object.isRequired
+  },
+  render: function() {
+    if (this.props.filePair.are_same_pixels) {
+      return <div className="no-changes">(Pixels are identical)</div>;
+    } else {
+      return null;
+    }
   }
 });

--- a/webdiff/static/js/image.jsx
+++ b/webdiff/static/js/image.jsx
@@ -119,7 +119,9 @@ var ImageDiff = React.createClass({
  */
 function makePerceptualBoxDiv(filePair, scaleDown) {
   var padding = 5;  // try not to obscure anything inside the box
-  if (filePair.diffData && filePair.diffData.isSameDimensions) {
+  if (filePair.diffData &&
+      filePair.diffData.isSameDimensions &&
+      filePair.diffData.diffBounds) {
     var bbox = filePair.diffData.diffBounds;
     var styles = {
       top: Math.floor(scaleDown * (bbox.top - padding)) + 'px',

--- a/webdiff/static/js/util.js
+++ b/webdiff/static/js/util.js
@@ -79,38 +79,6 @@ var SetIntervalMixin = {
 };
 
 
-// Global Resemble.js config.
-resemble.outputSettings({
-  errorColor: {
-    red: 255,
-    green: 0,
-    blue: 0
-  },
-  errorType: 'movement',
-  transparency: 0.0,  // don't include any of the original image.
-  ignoreAntialiasing: true
-});
-
-// Compute a perceptual diff using Resemble.js.
-// This memoizes the diff to facilitate working with React.
-// Returns deferred Resemble diff data.
-function computePerceptualDiff(fileA, fileB) {
-  if (!resemble.cache) resemble.cache = {};
-
-  return new Promise(function(resolve, reject) {
-    var key = [fileA, fileB].join(':');
-    var v = resemble.cache[key];
-    if (v) {
-      resolve(v);
-    } else {
-      resemble(fileB).compareTo(fileA).onComplete(function(data) {
-        resemble.cache[key] = data;
-        resolve(data);
-      });
-    }
-  });
-}
-
 function makeImage(dataURI) {
   var img = new Image();
   img.src = dataURI;

--- a/webdiff/templates/base.html
+++ b/webdiff/templates/base.html
@@ -12,7 +12,6 @@
   <script src="/static/components/react/react.js"></script>
   <script src="/static/components/react/JSXTransformer.js"></script>
   <script src="/static/components/react-router/dist/react-router.js"></script>
-  <script src="/static/components/resemblejs/resemble.js"></script>
 
   <script src="/static/codediff.js/difflib.js"></script>
   <script src="/static/codediff.js/codediff.js"></script>

--- a/webdiff/templates/file_diff.html
+++ b/webdiff/templates/file_diff.html
@@ -14,6 +14,7 @@
 <script>
 var pairs = {{pairs|tojson}};
 var initialIdx = {{idx|tojson}};
+var HAS_IMAGE_MAGICK = {{has_magick|tojson}};
 </script>
 
 <script type="text/jsx;harmony=true" src="/static/js/util.js"></script>

--- a/webdiff/util.py
+++ b/webdiff/util.py
@@ -1,15 +1,40 @@
 '''Utility code for webdiff'''
-import os
-import hashlib
 from collections import defaultdict
 import copy
+import functools
+import hashlib
 import mimetypes
+import os
+import subprocess
+import tempfile
+import time
+
 from PIL import Image
 
 import github_fetcher
 
+
+class ImageMagickNotAvailableError(Exception):
+    pass
+
+
 textchars = ''.join(map(chr, [7,8,9,10,12,13,27] + range(0x20, 0x100)))
 is_binary_string = lambda bytes: bool(bytes.translate(None, textchars))
+
+
+# via https://wiki.python.org/moin/PythonDecoratorLibrary#Memoize
+def memoize(obj):
+    """Decorator to memoize a function."""
+    cache = obj.cache = {}
+
+    @functools.wraps(obj)
+    def memoizer(*args, **kwargs):
+        key = str(args) + str(kwargs)
+        if key not in cache:
+            cache[key] = obj(*args, **kwargs)
+        return cache[key]
+    return memoizer
+
 
 def is_binary_file(filename):
   return is_binary_string(open(filename, 'rb').read(1024))
@@ -78,12 +103,19 @@ def _convert_to_pair_objects(pairs):
 def _annotate_file_pair(d, a_dir, b_dir):
     a_path = os.path.join(a_dir, d['a']) if d['a'] else None
     b_path = os.path.join(b_dir, d['b']) if d['b'] else None
+    d['a_path'] = a_path
+    d['b_path'] = b_path
 
     # Attach image metadata if applicable.
     if is_image_diff(d):
         d['is_image_diff'] = True
         if d['a']: d['image_a'] = _image_metadata(a_path)
         if d['b']: d['image_b'] = _image_metadata(b_path)
+        if d['a'] and d['b']:
+            try:
+                d['are_same_pixels'], _ = generate_pdiff_image(a_path, b_path)
+            except ImageMagickError:
+                d['are_same_pixels'] = False
 
     if a_path and b_path:
         d['no_changes'] = _are_files_identical(a_path, b_path)
@@ -221,3 +253,62 @@ def diff_for_args(args):
         gh = args['github']
         a_dir, b_dir = github_fetcher.fetch_pull_request(gh['owner'], gh['repo'], gh['num'])
         return [a_dir, b_dir] + [find_diff(a_dir, b_dir)]
+
+
+def is_imagemagick_available():
+    try:
+        # this swallows stdout/stderr
+        subprocess.check_output(['identify', '--version'])
+    except (subprocess.CalledProcessError, OSError):
+        return False
+    return True
+
+
+@memoize
+def generate_pdiff_image(before_path, after_path):
+    '''Generate a perceptual diff between the before/after images.
+
+    This runs the ImageMagick compare command.
+
+    Returns: (are_images_identical, path_to_pdiff_png)
+    '''
+    if not is_imagemagick_available():
+        raise ImageMagickNotAvailableError()
+
+    _, diff_path = tempfile.mkstemp(suffix='.png')
+
+    # The compare command returns:
+    #   0 on success & similar images
+    #   1 on success & dissimilar images
+    #   2 on failure
+    result = subprocess.call([
+        'compare',
+        '-metric', 'RMSE',
+        '-highlight-color', 'Red',
+        '-compose', 'Src',
+        before_path, after_path, diff_path
+    ])
+    if result == 2:
+        raise ImageMagickError('compare failed. Perhaps image dimensions differ.')
+    if result == 0:
+        return True, diff_path
+    return False, diff_path
+
+
+@memoize
+def generate_dilated_pdiff_image(diff_path):
+    '''Given a pdiff image, dilate it to highlight small differences.'''
+
+    # Dilate the diff image (to highlight small differences) and make it red.
+    _, diff_dilate_path = tempfile.mkstemp(suffix='.png')
+    subprocess.check_call([
+        'convert',
+        diff_path,
+        '-monochrome',
+        '-negate',
+        '-morphology', 'Dilate', 'Disk:5.5',
+        '-negate',
+        '-fill', 'Red', '-opaque', 'Black',
+        diff_dilate_path
+    ])
+    return diff_dilate_path

--- a/webdiff/util.py
+++ b/webdiff/util.py
@@ -286,13 +286,17 @@ def generate_pdiff_image(before_path, after_path):
     #   0 on success & similar images
     #   1 on success & dissimilar images
     #   2 on failure
-    result = subprocess.call([
-        'compare',
-        '-metric', 'RMSE',
-        '-highlight-color', 'Red',
-        '-compose', 'Src',
-        before_path, after_path, diff_path
-    ])
+    PIPE = subprocess.PIPE
+    p = subprocess.Popen([
+            'compare',
+            '-metric', 'RMSE',
+            '-highlight-color', 'Red',
+            '-compose', 'Src',
+            before_path, after_path, diff_path
+        ], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    output, err = p.communicate()  # `compare` is noisy; this swallows its output
+    result = p.returncode
+
     if result == 2:
         raise ImageMagickError('compare failed. Perhaps image dimensions differ.')
     if result == 0:

--- a/webdiff/util.py
+++ b/webdiff/util.py
@@ -19,6 +19,10 @@ class ImageMagickNotAvailableError(Exception):
     pass
 
 
+class ImageMagickError(Exception):
+    pass
+
+
 textchars = ''.join(map(chr, [7,8,9,10,12,13,27] + range(0x20, 0x100)))
 is_binary_string = lambda bytes: bool(bytes.translate(None, textchars))
 
@@ -324,4 +328,11 @@ def get_pdiff_bbox(diff_path):
     if not m:
         raise ImageMagickError('Unexpected identify output: %s' % out)
     width, height, left, top = [int(x) for x in m.groups()]
-    return {'width': width, 'height': height, 'left': left, 'top': top}
+    return {
+        'width': width,
+        'height': height,
+        'left': left,
+        'top': top,
+        'bottom': top + height,
+        'right': left + width
+    }

--- a/webdiff/util.py
+++ b/webdiff/util.py
@@ -5,6 +5,7 @@ import functools
 import hashlib
 import mimetypes
 import os
+import re
 import subprocess
 import tempfile
 import time
@@ -312,3 +313,15 @@ def generate_dilated_pdiff_image(diff_path):
         diff_dilate_path
     ])
     return diff_dilate_path
+
+
+@memoize
+def get_pdiff_bbox(diff_path):
+    '''Returns {top,left,width,height} for the content of a pdiff.'''
+    out = subprocess.check_output(['identify', '-format', '%@', diff_path])
+    # This looks like "26x94+0+830"
+    m = re.match(r'^(\d+)x(\d+)\+(\d+)\+(\d+)', out)
+    if not m:
+        raise ImageMagickError('Unexpected identify output: %s' % out)
+    width, height, left, top = [int(x) for x in m.groups()]
+    return {'width': width, 'height': height, 'left': left, 'top': top}


### PR DESCRIPTION
This change:

- Moves pdiff computation into Python & drops ResembleJS. This should be a performance win.
- Adds support for perceptual diffs, i.e. showing you precisely where the pixels are.
- Clearly indicates when an image is pixel-for-pixel identical, but the files still differ.

![screen recording 2015-03-27 at 05 35 pm](https://cloud.githubusercontent.com/assets/98301/6877485/c25132ca-d4a7-11e4-9041-decef9beab9c.gif)

Fixes #92
Fixes #96