### PR TITLE
Make diff generation lazy

### DIFF
--- a/tests/util_test.js
+++ b/tests/util_test.js
@@ -1,5 +1,9 @@
 QUnit.test('util.filePairDisplayName', function(assert) {
-  assert.deepEqual(filePairDisplayName({type: 'delete', path: 'dir/file.json'}),
+  assert.deepEqual(filePairDisplayName({
+                      type: 'delete',
+                      a: 'dir/file.json',
+                      b: null
+                   }),
                    'dir/file.json');
 
   var rename = function(a, b) {

--- a/webdiff/app.py
+++ b/webdiff/app.py
@@ -175,11 +175,17 @@ def index():
 @app.route("/<int:idx>")
 def file_diff(idx):
     idx = int(idx)
-    pairs = [diff.get_thin_dict(d) for d in DIFF]
+    pairs = diff.get_thin_list(DIFF)
     return render_template('file_diff.html',
                            idx=idx,
                            has_magick=util.is_imagemagick_available(),
                            pairs=pairs)
+
+
+@app.route('/thick/<int:idx>')
+def thick_diff(idx):
+    idx = int(idx)
+    return jsonify(diff.get_thick_dict(DIFF[idx]))
 
 
 @app.route('/favicon.ico')

--- a/webdiff/argparser.py
+++ b/webdiff/argparser.py
@@ -4,6 +4,7 @@ import os
 import re
 
 import dirdiff
+import githubdiff
 import github_fetcher
 from localfilediff import LocalFileDiff
 
@@ -96,4 +97,4 @@ def diff_for_args(args):
 
     if 'github' in args:
         gh = args['github']
-        return github_fetcher.fetch_pull_request(gh['owner'], gh['repo'], gh['num'])
+        return githubdiff.fetch_pull_request(gh['owner'], gh['repo'], gh['num'])

--- a/webdiff/argparser.py
+++ b/webdiff/argparser.py
@@ -96,5 +96,4 @@ def diff_for_args(args):
 
     if 'github' in args:
         gh = args['github']
-        a_dir, b_dir = github_fetcher.fetch_pull_request(gh['owner'], gh['repo'], gh['num'])
-        return dirdiff.diff(a_dir, b_dir)
+        return github_fetcher.fetch_pull_request(gh['owner'], gh['repo'], gh['num'])

--- a/webdiff/diff.py
+++ b/webdiff/diff.py
@@ -21,7 +21,7 @@ def get_thin_dict(diff):
 
 def get_thick_dict(diff):
     '''Similar to thin_dict, but includes potentially expensive fields.'''
-    d = get_thick_dict(diff)
+    d = get_thin_dict(diff)
     d.update({
         'is_image_diff': is_image_diff(diff),
         'no_changes': diff.no_changes()
@@ -33,11 +33,21 @@ def get_thick_dict(diff):
             try:
                 d['are_same_pixels'], _ = util.generate_pdiff_image(
                         diff.a_path, diff.b_path)
-            except ImageMagickError:
+            except util.ImageMagickError:
                 d['are_same_pixels'] = False
-            except ImageMagickNotAvailableError:
+            except util.ImageMagickNotAvailableError:
                 pass
     return d
+
+
+def get_thin_list(diffs, thick_idx=None):
+    '''Convert a list of diffs to dicts. This adds an 'idx' field.'''
+    ds = [get_thin_dict(d) for d in diffs]
+    if thick_idx is not None:
+        ds[thick_idx] = get_thick_dict(ds[idx])
+    for i, d in enumerate(ds):
+        d['idx'] = i
+    return ds
 
 
 def is_image_diff(diff):

--- a/webdiff/diff.py
+++ b/webdiff/diff.py
@@ -1,4 +1,14 @@
-'''Utility code for working with Diff objects.'''
+'''Utility code for working with Diff objects.
+
+Diff objects must have these properties:
+    - a      Name of the file on the left side of a diff      
+    - a_path Path to a copy of the left side file on local disk.
+    - b      (like a)
+    - b_path (like a_path)
+    - type   One of {'change', 'move', 'add', 'delete'}
+
+For concrete implementations, see githubdiff and localfilediff.
+'''
 
 import mimetypes
 
@@ -84,10 +94,11 @@ def find_diff_index(diffs, side, path):
     Returns None if there's no diff for the (side, path) pair.
     '''
     assert side in ('a', 'b')
-    # TODO: os.path.normpath
+    norm = os.path.normpath
+    path = norm(path)
     for idx, diff in enumerate(diffs):
-        if side == 'a' and diff.a == path:
+        if side == 'a' and norm(diff.a) == path:
             return idx
-        if side == 'b' and diff.b == path:
+        if side == 'b' and norm(diff.b) == path:
             return idx
     return None

--- a/webdiff/diff.py
+++ b/webdiff/diff.py
@@ -24,7 +24,7 @@ def get_thick_dict(diff):
     d = get_thin_dict(diff)
     d.update({
         'is_image_diff': is_image_diff(diff),
-        'no_changes': diff.no_changes()
+        'no_changes': no_changes(diff)
     })
     if d['is_image_diff']:
         if d['a']: d['image_a'] = util.image_metadata(diff.a_path)
@@ -48,6 +48,12 @@ def get_thin_list(diffs, thick_idx=None):
     for i, d in enumerate(ds):
         d['idx'] = i
     return ds
+
+
+def no_changes(diff):
+    if diff.a_path and diff.b_path:
+        return util.are_files_identical(diff.a_path, diff.b_path)
+    return False
 
 
 def is_image_diff(diff):

--- a/webdiff/diff.py
+++ b/webdiff/diff.py
@@ -1,0 +1,77 @@
+'''Utility code for working with Diff objects.'''
+
+import mimetypes
+
+import util
+
+def get_thin_dict(diff):
+    '''Returns a dict containing minimal data on the diff.
+
+    This includes:
+      - before/after file name
+      - change type (add, delete, move, change)
+      - diffstats
+    '''
+    return {
+        'a': diff.a,
+        'b': diff.b,
+        'type': diff.type
+    }
+
+
+def get_thick_dict(diff):
+    '''Similar to thin_dict, but includes potentially expensive fields.'''
+    d = get_thick_dict(diff)
+    d.update({
+        'is_image_diff': is_image_diff(diff),
+        'no_changes': diff.no_changes()
+    })
+    if d['is_image_diff']:
+        if d['a']: d['image_a'] = util.image_metadata(diff.a_path)
+        if d['b']: d['image_b'] = util.image_metadata(diff.b_path)
+        if d['a'] and d['b']:
+            try:
+                d['are_same_pixels'], _ = util.generate_pdiff_image(
+                        diff.a_path, diff.b_path)
+            except ImageMagickError:
+                d['are_same_pixels'] = False
+            except ImageMagickNotAvailableError:
+                pass
+    return d
+
+
+def is_image_diff(diff):
+    '''Determine whether this diff is appropriate for image diff UI.
+
+    This uses the a_path and b_path properties of the diff object.
+    '''
+    def is_image(path):
+        if path is None: return False
+        mime_type, enc = mimetypes.guess_type(path)
+        return (mime_type and mime_type.startswith('image/') and enc is None)
+
+    left_img = is_image(diff.a_path)
+    right_img = is_image(diff.b_path)
+
+    if left_img and right_img:
+        return True
+    elif left_img and diff.b_path is None:
+        return True
+    elif right_img and diff.a_path is None:
+        return True
+    return False
+
+
+def find_diff_index(diffs, side, path):
+    '''Given a side & path, find the index in the diff for it.
+    
+    Returns None if there's no diff for the (side, path) pair.
+    '''
+    assert side in ('a', 'b')
+    # TODO: os.path.normpath
+    for idx, diff in enumerate(diffs):
+        if side == 'a' and diff.a == path:
+            return idx
+        if side == 'b' and diff.b == path:
+            return idx
+    return None

--- a/webdiff/diff.py
+++ b/webdiff/diff.py
@@ -11,6 +11,7 @@ For concrete implementations, see githubdiff and localfilediff.
 '''
 
 import mimetypes
+import os
 
 import util
 
@@ -94,7 +95,10 @@ def find_diff_index(diffs, side, path):
     Returns None if there's no diff for the (side, path) pair.
     '''
     assert side in ('a', 'b')
-    norm = os.path.normpath
+    def norm(p):
+        if p is None: return None
+        return os.path.normpath(p)
+
     path = norm(path)
     for idx, diff in enumerate(diffs):
         if side == 'a' and norm(diff.a) == path:

--- a/webdiff/dirdiff.py
+++ b/webdiff/dirdiff.py
@@ -1,0 +1,98 @@
+'''Compute the diff between two directories on local disk.'''
+
+from collections import defaultdict
+import copy
+import os
+
+from localfilediff import LocalFileDiff
+import util
+
+
+def diff(a_dir, b_dir):
+    pairs = find_diff(a_dir, b_dir)
+    moves, pairs = find_moves(pairs)
+
+    diffs = (
+        [LocalFileDiff(a_dir, a, b_dir, b, False) for a, b in pairs] +
+        [LocalFileDiff(a_dir, a, b_dir, b, True) for a, b in moves])
+
+    # sort "change" before "delete" in a move, which is easier to understand.
+    diffs.sort(key=lambda diff: (diff.a_path, 0 if diff.b else 1))
+
+    return diffs
+
+
+def find_diff(a, b):
+    '''Walk directories a and b and pair off files.
+    
+    Returns a list of pairs of full paths to matched a/b files.
+    '''
+    a_files = []
+    b_files = []
+    def accum(arg, dirname, fnames):
+        for fname in fnames:
+            path = os.path.join(dirname, fname)
+            if not os.path.isdir(path):
+                arg.append(path)
+
+    assert os.path.isdir(a)
+    assert os.path.isdir(b)
+
+    os.path.walk(a, accum, a_files)
+    os.path.walk(b, accum, b_files)
+
+    a_files = [os.path.relpath(x, start=a) for x in a_files]
+    b_files = [os.path.relpath(x, start=b) for x in b_files]
+
+    pairs = pair_files(a_files, b_files)
+
+    def safejoin(d, p):
+        if p is None: return None
+        return os.path.join(d, p)
+
+    return [(safejoin(a, arel),
+             safejoin(b, brel)) for arel, brel in pairs]
+
+
+def pair_files(a_files, b_files):
+    '''Paths must be relative to the diff root for each side.'''
+    pairs = []
+    for f in a_files[:]:
+        if f in b_files:
+            i = a_files.index(f)
+            j = b_files.index(f)
+            pairs.append((f, f))
+            del a_files[i]
+            del b_files[j]
+        else:
+            pairs.append((f, None))  # delete
+
+    for f in b_files:
+        pairs.append((None, f))  # add
+
+    return pairs
+
+
+def find_moves(pairs):
+    add_delete_pairs = defaultdict(lambda: [None,None])
+    for idx, (a, b) in enumerate(pairs):
+        if b and not a:  # add
+            add_delete_pairs[util.contentHash(b)][1] = idx
+        elif a and not b:  # delete
+            add_delete_pairs[util.contentHash(a)][0] = idx
+
+    indices_to_delete = []
+    moves = []
+    for _, (aIdx, bIdx) in add_delete_pairs.iteritems():
+        if aIdx == None or bIdx == None:
+            continue
+
+        # replace the "add" with a "change"
+        indices_to_delete.append(bIdx)
+        moves.append((pairs[aIdx][0], pairs[bIdx][1]))
+
+    remaining_pairs = copy.deepcopy(pairs)
+    for idx in reversed(sorted(indices_to_delete)):
+        del remaining_pairs[idx]
+
+    return moves, remaining_pairs

--- a/webdiff/githubdiff.py
+++ b/webdiff/githubdiff.py
@@ -20,6 +20,7 @@ class GitHubDiff(object):
         self._file = github_file
         self.type = {
                 'modified': 'change',
+                'changed': 'change',  # How does this differ from 'modified'?
                 'renamed': 'move',
                 'added': 'add',
                 'removed': 'delete'

--- a/webdiff/githubdiff.py
+++ b/webdiff/githubdiff.py
@@ -1,0 +1,79 @@
+'''Diff class for GitHub pull requests.
+
+The main feature of note is that this fetches files from GitHub lazily when
+a_path and b_path are accessed. This allows large PRs to be loaded quickly
+--more quickly than GitHub's UI does it!
+'''
+
+import os
+import tempfile
+import sys
+
+from util import memoize
+from github_fetcher import github
+
+
+class GitHubDiff(object):
+    '''pr and github_file are objects from the Python GitHub API.'''
+    def __init__(self, pr, github_file):
+        self._pr = pr
+        self._file = github_file
+        self.type = {
+                'modified': 'change',
+                'renamed': 'move',
+                'added': 'add',
+                'removed': 'delete'
+                }[github_file.status]
+        self._a_path = None
+        self._b_path = None
+
+    @property
+    def a(self):
+        if self.type == 'move':
+            return self._file.raw_data['previous_filename']
+        elif self.type == 'add':
+            return None
+        else:
+            return self._file.filename
+
+    @property
+    def b(self):
+        if self.type == 'delete':
+            return None
+        else:
+            return self._file.filename
+
+    # NB: these are @memoize'd via fetch()
+    @property
+    def a_path(self):
+        return fetch(self._pr.base.repo, self.a, self._pr.base.sha)
+
+    @property
+    def b_path(self):
+        return fetch(self._pr.head.repo, self.b, self._pr.head.sha)
+
+    def __repr__(self):
+        return '%s (%s)' % (self.a or self.b, self.type)
+
+    # TOOD: diffstats are accessible via file.{changes,additions,deletions}
+
+
+def fetch_pull_request(owner, repo, num):
+    '''Return a list of Diff objects for a pull request.'''
+    sys.stderr.write('Loading pull request %s/%s#%s from github...\n' % (
+            owner, repo, num))
+    g = github()
+    pr = g.get_user(owner).get_repo(repo).get_pull(num)
+    files = pr.get_files()
+
+    return [GitHubDiff(pr, f) for f in files]
+
+
+@memoize
+def fetch(repo, filename, sha):
+    if filename is None: return None
+    data = repo.get_file_contents(filename, sha).decoded_content
+    _, ext = os.path.splitext(filename)
+    fd, path = tempfile.mkstemp(suffix=ext)
+    open(path, 'wb').write(data)
+    return path

--- a/webdiff/localfilediff.py
+++ b/webdiff/localfilediff.py
@@ -41,10 +41,5 @@ class LocalFileDiff(object):
             return 'move'
         return 'change'
 
-    def no_changes(self):
-        if self.a_path and self.b_path:
-            return util.are_files_identical(self.a_path, self.b_path)
-        return False
-
     def __repr__(self):
         return '%s/%s (%s)' % (self.a, self.b, self.type)

--- a/webdiff/localfilediff.py
+++ b/webdiff/localfilediff.py
@@ -1,0 +1,50 @@
+'''This class represents the diff between two files on local disk.'''
+
+import os
+import mimetypes
+import util
+
+class LocalFileDiff(object):
+    def __init__(self, a_root, a_path, b_root, b_path, is_move):
+        '''A before/after file pair on local disk
+        
+        Args:
+            a_path, b_path: full paths to the files on disk. Either (but not
+                both) may be None.
+            a_root, b_root: Paths to the root of diff.
+            is_move: Is this a pure move between the two files?
+        '''
+        assert (a_path is not None) or (b_path is not None)
+        self.a_path = a_path
+        self.b_path = b_path
+        self.a_root = a_root
+        self.b_root = b_root
+        self.is_move = is_move
+
+    @property
+    def a(self):
+        if self.a_path is None: return None
+        return os.path.relpath(self.a_path, self.a_root)
+
+    @property
+    def b(self):
+        if self.b_path is None: return None
+        return os.path.relpath(self.b_path, self.b_root)
+
+    @property
+    def type(self):
+        if self.a_path is None:
+            return 'add'
+        elif self.b_path is None:
+            return 'delete'
+        elif self.is_move:
+            return 'move'
+        return 'change'
+
+    def no_changes(self):
+        if self.a_path and self.b_path:
+            return util.are_files_identical(self.a_path, self.b_path)
+        return False
+
+    def __repr__(self):
+        return '%s/%s (%s)' % (self.a, self.b, self.type)

--- a/webdiff/static/js/components.jsx
+++ b/webdiff/static/js/components.jsx
@@ -67,7 +67,8 @@ var makeRoot = function(filePairs, initiallySelectedIndex) {
           <FileSelector selectedFileIndex={idx}
                         filePairs={this.props.filePairs}
                         fileChangeHandler={this.selectIndex} />
-          <DiffView filePair={filePair}
+          <DiffView key={'diff-' + idx}
+                    thinFilePair={filePair}
                     imageDiffMode={this.state.imageDiffMode}
                     pdiffMode={this.state.pdiffMode}
                     changeImageDiffModeHandler={this.changeImageDiffModeHandler}
@@ -237,17 +238,32 @@ var FileDropdown = React.createClass({
 // A diff for a single pair of files (left/right).
 var DiffView = React.createClass({
   propTypes: {
-    filePair: React.PropTypes.object.isRequired,
+    thinFilePair: React.PropTypes.object.isRequired,
     imageDiffMode: React.PropTypes.oneOf(IMAGE_DIFF_MODES).isRequired,
     pdiffMode: React.PropTypes.number,
     changeImageDiffModeHandler: React.PropTypes.func.isRequired,
     changePdiffMode: React.PropTypes.func.isRequired
   },
+  getInitialState: function() {
+    // Only the "thin" file pair is available on page load.
+    // To get the "thick" file pair, we need to issue an XHR
+    return {filePair: null};
+  },
+  componentDidMount: function() {
+    getThickDiff(this.props.thinFilePair.idx).done(filePair => {
+      this.setState({filePair});
+    });
+  },
   render: function() {
-    if (this.props.filePair.is_image_diff) {
-      return <ImageDiff {...this.props} />;
+    var filePair = this.state.filePair;
+    if (!filePair) {
+      return <div>Loading…</div>;
+    }
+
+    if (filePair.is_image_diff) {
+      return <ImageDiff filePair={filePair} {...this.props} />;
     } else {
-      return <CodeDiff filePair={this.props.filePair} />;
+      return <CodeDiff filePair={filePair} />;
     }
   }
 });

--- a/webdiff/static/js/file_diff.js
+++ b/webdiff/static/js/file_diff.js
@@ -40,6 +40,25 @@ function renderDiff(pathBefore, pathAfter, contentsBefore, contentsAfter) {
   return diffDiv;
 }
 
+/**
+ * Get thick file diff information from the server.
+ * @param {number} index Index of this diff in the diff list
+ * @return {jQuery.Deferred} Deferred object for the thick diff.
+ */
+function getThickDiff(index) {
+  var cache = getThickDiff.cache;
+  if (cache[index]) {
+    return $.when(cache[index]);
+  }
+
+  var deferred = $.getJSON('/thick/' + index);
+  deferred.done(function(data) {
+    cache[index] = data;
+  });
+  return deferred;
+}
+getThickDiff.cache = [];
+
 
 function extractFilename(path) {
   var parts = path.split('/');

--- a/webdiff/static/js/util.js
+++ b/webdiff/static/js/util.js
@@ -9,7 +9,7 @@
  */
 function filePairDisplayName(filePair) {
   if (filePair.type != 'move') {
-    return filePair.path;
+    return filePair.a || filePair.b;
   }
 
   // Factor out shared components (folder names, basename, extension) in the

--- a/webdiff/util.py
+++ b/webdiff/util.py
@@ -1,9 +1,7 @@
 '''Utility code for webdiff'''
-from collections import defaultdict
 import copy
 import functools
 import hashlib
-import mimetypes
 import os
 import re
 import subprocess
@@ -45,169 +43,21 @@ def is_binary_file(filename):
   return is_binary_string(open(filename, 'rb').read(1024))
 
 
-def find_diff(a, b):
-    '''Walk directories a and b and pair off files.'''
-    a_files = []
-    b_files = []
-    def accum(arg, dirname, fnames):
-        for fname in fnames:
-            path = os.path.join(dirname, fname)
-            if not os.path.isdir(path):
-                arg.append(path)
-
-    assert os.path.isdir(a)
-    assert os.path.isdir(b)
-
-    os.path.walk(a, accum, a_files)
-    os.path.walk(b, accum, b_files)
-
-    a_files = [os.path.relpath(x, start=a) for x in a_files]
-    b_files = [os.path.relpath(x, start=b) for x in b_files]
-
-    pairs = _convert_to_pair_objects(pair_files(a_files, b_files))
-    diff = annotate_file_pairs(pairs, a, b)
-
-    # this sorts "changes" before "delete" in a move, which is much easier to understand.
-    diff.sort(key=lambda x: (x['path'], 0 if x['b'] else 1))
-    for i, d in enumerate(diff):
-        d['idx'] = i
-    return diff
+@memoize
+def contentHash(path):
+    return hashlib.sha512(open(path).read()).digest()
 
 
-def pair_files(a_files, b_files):
-    pairs = []
-    for f in a_files[:]:
-        if f in b_files:
-            i = a_files.index(f)
-            j = b_files.index(f)
-            pairs.append((f, f))
-            del a_files[i]
-            del b_files[j]
-        else:
-            pairs.append((f, None))  # delete
-
-    for f in b_files:
-        pairs.append((None, f))  # add
-
-    return pairs
-
-
-def _convert_to_pair_objects(pairs):
-    '''Convert (a, b) pairs to {a, b, path, type} filePair objects.'''
-    diffs = []
-    for i, (a, b) in enumerate(pairs):
-        d = { 'a': a, 'b': b, 'path': b or a, 'type': 'change' }
-        if a is None:
-            d['type'] = 'add'
-        elif b is None:
-            d['type'] = 'delete'
-        diffs.append(d)
-    return diffs
-
-
-def _annotate_file_pair(d, a_dir, b_dir):
-    a_path = os.path.join(a_dir, d['a']) if d['a'] else None
-    b_path = os.path.join(b_dir, d['b']) if d['b'] else None
-    d['a_path'] = a_path
-    d['b_path'] = b_path
-
-    # Attach image metadata if applicable.
-    if is_image_diff(d):
-        d['is_image_diff'] = True
-        if d['a']: d['image_a'] = _image_metadata(a_path)
-        if d['b']: d['image_b'] = _image_metadata(b_path)
-        if d['a'] and d['b']:
-            try:
-                d['are_same_pixels'], _ = generate_pdiff_image(a_path, b_path)
-            except ImageMagickError:
-                d['are_same_pixels'] = False
-            except ImageMagickNotAvailableError:
-                pass
-
-    if a_path and b_path:
-        d['no_changes'] = _are_files_identical(a_path, b_path)
-    else:
-        d['no_changes'] = False
-
-
-def annotate_file_pairs(file_pairs, a_dir, b_dir):
-    '''Add annotations (e.g. stats, image info, moves) to filePair objects.'''
-    file_pairs = find_moves(file_pairs, a_dir, b_dir)
-
-    for d in file_pairs:
-        _annotate_file_pair(d, a_dir, b_dir)
-
-    return file_pairs
-
-
-def find_moves(diff, a_dir, b_dir):
-    def hash(d, path):
-        return _contentHash(os.path.join(d, path))
-
-    out = copy.deepcopy(diff)
-    add_delete_pairs = defaultdict(lambda: [None,None])
-
-    for idx, pair in enumerate(diff):
-        if pair['type'] == 'add':
-            add_delete_pairs[hash(b_dir, pair['b'])][1] = idx
-        elif pair['type'] == 'delete':
-            add_delete_pairs[hash(a_dir, pair['a'])][0] = idx
-
-    for _, (aIdx, bIdx) in add_delete_pairs.iteritems():
-        if aIdx == None or bIdx == None:
-            continue
-
-        a = diff[aIdx]
-        b = diff[bIdx]
-
-        # replace the "add" with a "change"
-        out[bIdx] = {
-            'a': a['a'],
-            'b': b['b'],
-            'path': a['a'],  # ???
-            'type': 'move'
-        }
-
-    return out
-
-
-def is_image_diff(diff):
-    def is_image(path):
-        if path is None: return False
-        mime_type, enc = mimetypes.guess_type(path)
-        return (mime_type and mime_type.startswith('image/') and enc is None)
-
-    left_img = is_image(diff['a'])
-    right_img = is_image(diff['b'])
-
-    if left_img and right_img:
-        return True
-    elif left_img and diff['b'] is None:
-        return True
-    elif right_img and diff['a'] is None:
-        return True
-    return False
-
-
-hash_cache = {}
-def _contentHash(path):
-    global hash_cache
-    if path in hash_cache:
-        return hash_cache[path]
-    sha = hashlib.sha512(open(path).read()).digest()
-    hash_cache[path] = sha
-    return sha
-
-
-def _are_files_identical(path1, path2):
+def are_files_identical(path1, path2):
     # Check if anything has changed.
     # Compare lengths & then checksums.
     if os.path.getsize(path1) != os.path.getsize(path2):
         return False
-    return _contentHash(path1) == _contentHash(path2) 
+    return contentHash(path1) == contentHash(path2) 
 
 
-def _image_metadata(path):
+def image_metadata(path):
+    '''Returns a dict with metadata about the image located at path.'''
     md = { 'num_bytes': os.path.getsize(path) }
     try:
         im = Image.open(path)
@@ -217,49 +67,6 @@ def _image_metadata(path):
         pass
     return md
 
-
-def _shim_for_file_diff(a_file, b_file):
-    '''Sets A_DIR, B_DIR and DIFF to do a one-file diff.'''
-    a_dir = os.path.dirname(a_file)
-    a_file = os.path.basename(a_file)
-    b_dir = os.path.dirname(b_file)
-    b_file = os.path.basename(b_file)
-    diff = annotate_file_pairs([{
-             'a': a_file,
-             'b': b_file,
-             'idx': 0,
-             'path': a_file,
-             'type': 'change'}],  # 'change' is the only likely case.
-             a_dir, b_dir)
-    return a_dir, b_dir, diff
-
-
-def diff_for_args(args):
-    """Returns A_DIR, B_DIR, find_diff() for parsed command line args.
-    
-    DIFF looks something like:
-    [ {
-        'a': '1_normal.jpg',
-        'is_image_diff': True,
-        'b': '1_normal.jpg',
-        'idx': 0,
-        'no_changes': False,
-        'image_a': {'width': 300, 'num_bytes': 20831, 'height': 300},
-        'image_b': {'width': 300, 'num_bytes': 20713, 'height': 300},
-        'path': '1_normal.jpg',
-        'type': 'change'
-      }, ... ]
-    """
-    if 'dirs' in args:
-        return list(args['dirs']) + [find_diff(*args['dirs'])]
-
-    if 'files' in args:
-        return _shim_for_file_diff(*args['files'])
-
-    if 'github' in args:
-        gh = args['github']
-        a_dir, b_dir = github_fetcher.fetch_pull_request(gh['owner'], gh['repo'], gh['num'])
-        return [a_dir, b_dir] + [find_diff(a_dir, b_dir)]
 
 
 @memoize

--- a/webdiff/util.py
+++ b/webdiff/util.py
@@ -10,8 +10,6 @@ import time
 
 from PIL import Image
 
-import github_fetcher
-
 
 class ImageMagickNotAvailableError(Exception):
     pass


### PR DESCRIPTION
This factors out two `Diff` classes: `LocalFileDiff` and `GitHubDiff`. These have the ability to generate diff information on demand. For example, `GitHubDiff` only pulls down files from GitHub when you view them in the web UI. This makes startup dramatically faster.

This cleans up a lot of code—the JSON objects that are passed from server to client are all generated in `diff.py` now, rather than in bits and pieces throughout the codebase.

Fixes #60 
Fixes #68 
Fixes #90 
See #97 