### PR TITLE
OAuth and highlight.js version bumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,17 @@ You can also use `webdiff` to view GitHub pull requests:
 
 This will download the files relevant to the Pull Request and run `webdiff`.
 
-If you run into GitHub API quota limits, you can set your credentials in a `.githubrc` file:
+If you run into GitHub API quota limits or you'd like to use webdiff with
+private repos, you can set your credentials in a `.githubrc` file:
 
 ```
 user.login: yourusername
-user.password: yourpassword
+user.token: your-personal-access-tokens
 ```
 
-Make sure you chmod this file to only be readable by yourself. In the future
-we'll support [Oauth][].
+Make sure you chmod this file to only be readable by yourself. You can generate
+a personal access token for webdiff via github.com → profile → Settings →
+Personal access tokens. Make sure to grant all the "repo" privileges.
 
 
 Development

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "jquery": "~2.1.1",
-    "highlightjs": "~8.0.0",
+    "highlightjs": "~9.2.0",
     "underscore": "~1.6.0",
     "react": "~0.12.2",
     "react-router": "~0.11.6"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask==0.10.1
 nose
 PyGithub==1.25.2
 pillow
+requests

--- a/webdiff/github_fetcher.py
+++ b/webdiff/github_fetcher.py
@@ -36,11 +36,23 @@ def github():
                 k, v = line.split(': ', 1)
                 kvs[k] = v
 
-            if not kvs.get('user.login'):
+            login = kvs.get('user.login')
+            if not login:
                 return simple_fallback('.githubrc missing user.login. Using anonymous API access.')
-            if not kvs.get('user.password'):
-                return simple_fallback('.githubrc missing user.password. Using anonymous API access.')
-            return Github(kvs['user.login'], kvs['user.password'])
+
+            password = kvs.get('user.password')
+            token = kvs.get('user.token')
+
+            if password and token:
+                raise OnlyPasswordOrToken('Only specify user.token or user.password '
+                                          'in your .githubrc file (got both)')
+
+            auth = token or password
+
+            if not auth:
+                return simple_fallback('.githubrc has neither user.password nor user.token.'
+                                       'Using anonymous API access.')
+            return Github(login, auth)
     else:
         return Github()
 
@@ -49,6 +61,9 @@ class NoRemoteError(Exception):
     pass
 
 class UnknownPullRequestError(Exception):
+    pass
+
+class OnlyPasswordOrToken(Exception):
     pass
 
 


### PR DESCRIPTION
The highlight.js version bump adds support for lots of ES6 features.

As it turns out, you could always generate a personal access token and use it as your `user.password`. So webdiff secretly supported OAuth all along! Now it's more explicit.

Fixes #106 
Fixes #103 