### PR TITLE
Add support for using a hostname

### DIFF
--- a/webdiff/app.py
+++ b/webdiff/app.py
@@ -52,7 +52,7 @@ app.config.from_envvar('WEBDIFF_CONFIG', silent=True)
 
 DIFF = None
 PORT = None
-HOSTNAME = "localhost"
+HOSTNAME = 'localhost'
 
 if app.config['TESTING'] or app.config['DEBUG']:
     handler = logging.StreamHandler()


### PR DESCRIPTION
Hey @danvk 

We use webdiff at my office for quickly sharing small code changes, hosting webdiffs on our dev boxes, and we love it. It's a great project.
However, webdiff not using a hostname for the web endpoint makes it difficult to share the diffs.
This is a small patch to add support for hostnames in webdiff.
A new config file option enables webdiff to start the diff using the clients hostname. This makes sharing a webdiff around a local network much easier.

All the tests passed (nosetests and http tests).

Here is a paste of the patch in action:
```
niko@cuba:~/Projects/webdiff on branch hostname (Unstaged Changes)$ git webdiff 
preexec - timestamp: Fri Nov  4 14:34:36 PDT 2016
Serving diffs on http://localhost:53988
Close the browser tab or hit Ctrl-C when you're done.
Created new window in existing browser session.
^CTraceback (most recent call last):
  File "/usr/local/bin/git-webdiff", line 9, in <module>
    load_entry_point('webdiff==0.12.1', 'console_scripts', 'git-webdiff')()
  File "/usr/local/lib/python2.7/dist-packages/webdiff-0.12.1-py2.7.egg/webdiff/gitwebdiff.py", line 22, in run
    'git difftool -d -x webdiff'.split(' ') + sys.argv[1:]))
  File "/usr/lib/python2.7/subprocess.py", line 523, in call
    return Popen(*popenargs, **kwargs).wait()


postexec - exit code: 130, elapsed time: 3.944s
niko@cuba:~/Projects/webdiff on branch hostname (Unstaged Changes)$ export WEBDIFF_CONFIG=~/.webdiff.cfg
preexec - timestamp: Fri Nov  4 14:35:24 PDT 2016
postexec - exit code: 0, elapsed time: .004s
niko@cuba:~/Projects/webdiff on branch hostname (Unstaged Changes)$ echo "USE_HOSTNAME=True" >> ~/.webdiff.cfg
preexec - timestamp: Fri Nov  4 14:35:56 PDT 2016
postexec - exit code: 0, elapsed time: .004s
niko@cuba:~/Projects/webdiff on branch hostname (Unstaged Changes)$ git webdiff 
preexec - timestamp: Fri Nov  4 14:35:58 PDT 2016
Serving diffs on http://cuba:59701
Close the browser tab or hit Ctrl-C when you're done.
Created new window in existing browser session.
^CTraceback (most recent call last):
  File "/usr/local/bin/git-webdiff", line 9, in <module>
    load_entry_point('webdiff==0.12.1', 'console_scripts', 'git-webdiff')()
  File "/usr/local/lib/python2.7/dist-packages/webdiff-0.12.1-py2.7.egg/webdiff/gitwebdiff.py", line 22, in run
    'git difftool -d -x webdiff'.split(' ') + sys.argv[1:]))
  File "/usr/lib/python2.7/subprocess.py", line 523, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/usr/lib/python2.7/subprocess.py", line 1389, in wait
    pid, sts = _eintr_retry_call(os.waitpid, self.pid, 0)


postexec - exit code: 130, elapsed time: 4.792s
niko@cuba:~/Projects/webdiff on branch hostname (Unstaged Changes)$ 
```
Let me know if there are any other bits of output or any screenshots that you'd like, I don't use github too often so I'm no pro :)

Cheers,
Niko 
