### PR TITLE
Exit cleanly from 'git webdiff'

### DIFF
--- a/webdiff/gitwebdiff.py
+++ b/webdiff/gitwebdiff.py
@@ -17,9 +17,12 @@ def run():
         # "git webdiff <sha>". This allows special treatment (e.g. for
         # staging diffhunks).
         os.environ['WEBDIFF_FROM_HEAD'] = 'yes'
-    
-    sys.exit(subprocess.call(
-        'git difftool -d -x webdiff'.split(' ') + sys.argv[1:]))
+
+    try:
+        subprocess.call('git difftool -d -x webdiff'.split(' ') + sys.argv[1:])
+    except KeyboardInterrupt:
+        # Don't raise an exception to the user when sigint is received
+        pass
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hey @danvk 

This is just a small patch to stop ```git webdiff``` from raising an exception to the user when they quit with Ctrl-C

### Before
```
niko@cuba:~/Projects/webdiff on branch clean-exit$ git checkout master
preexec - timestamp: Sun Nov  6 16:29:26 PST 2016
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.
postexec - exit code: 0, elapsed time: .006s
niko@cuba:~/Projects/webdiff on branch master$ echo " " >> setup.py 
preexec - timestamp: Sun Nov  6 16:29:34 PST 2016
postexec - exit code: 0, elapsed time: .003s
<Install>
niko@cuba:~/Projects/webdiff on branch master (Unstaged Changes)$ git webdiff
preexec - timestamp: Sun Nov  6 16:31:00 PST 2016
Serving diffs on http://localhost:57265
Close the browser tab or hit Ctrl-C when you're done.
Created new window in existing browser session.
^CTraceback (most recent call last):
  File "/usr/local/bin/git-webdiff", line 9, in <module>
    load_entry_point('webdiff==0.12.1', 'console_scripts', 'git-webdiff')()
  File "/usr/local/lib/python2.7/dist-packages/webdiff-0.12.1-py2.7.egg/webdiff/gitwebdiff.py", line 22, in run
    'git difftool -d -x webdiff'.split(' ') + sys.argv[1:]))
  File "/usr/lib/python2.7/subprocess.py", line 523, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/usr/lib/python2.7/subprocess.py", line 1389, in wait
    pid, sts = _eintr_retry_call(os.waitpid, self.pid, 0)
  File "/usr/lib/python2.7/subprocess.py", line 476, in _eintr_retry_call
    return func(*args)
KeyboardInterrupt

postexec - exit code: 130, elapsed time: 7.912s
niko@cuba:~/Projects/webdiff on branch master (Unstaged Changes)$ 
```

### After
```
niko@cuba:~/Projects/webdiff on branch master$ git checkout clean-exit 
preexec - timestamp: Sun Nov  6 16:32:14 PST 2016
Switched to branch 'clean-exit'
Your branch is up-to-date with 'origin/clean-exit'.
postexec - exit code: 0, elapsed time: .007s
niko@cuba:~/Projects/webdiff on branch clean-exit$ echo " " >> setup.py 
preexec - timestamp: Sun Nov  6 16:32:23 PST 2016
postexec - exit code: 0, elapsed time: .004s
niko@cuba:~/Projects/webdiff on branch clean-exit (Unstaged Changes)$ 
<Install>
niko@cuba:~/Projects/webdiff on branch clean-exit (Unstaged Changes)$ git webdiff
preexec - timestamp: Sun Nov  6 16:32:46 PST 2016
Serving diffs on http://localhost:34453
Close the browser tab or hit Ctrl-C when you're done.
Created new window in existing browser session.
^C
postexec - exit code: 130, elapsed time: 6.108s
niko@cuba:~/Projects/webdiff on branch clean-exit (Unstaged Changes)$ 
```
I've tested this locally and all unit tests pass.

Let me know if you need any other bits of output or screenshots.

Cheers,
Niko
