### PR TITLE
Python3 compatibility for webdiff-ing GitHub pull requests (issue #126)

### DIFF
--- a/webdiff/app.py
+++ b/webdiff/app.py
@@ -274,7 +274,7 @@ def run():
     try:
         parsed_args = argparser.parse(sys.argv[1:], VERSION)
     except argparser.UsageError as e:
-        sys.stderr.write('Error: %s\n\n' % e.message)
+        sys.stderr.write('Error: %s\n\n' % e)
         usage_and_die()
 
     DIFF = argparser.diff_for_args(parsed_args)

--- a/webdiff/github_fetcher.py
+++ b/webdiff/github_fetcher.py
@@ -134,6 +134,6 @@ def _parse_remotes(remote_lines):
 
 def _get_remotes():
     remote_lines = subprocess.Popen(
-        ['git', 'remote', '-v'], stdout=subprocess.PIPE).communicate()[0].split(b'\n')
+        ['git', 'remote', '-v'], stdout=subprocess.PIPE).communicate()[0].decode().split('\n')
     return _parse_remotes(remote_lines)
 

--- a/webdiff/static/js/components.jsx
+++ b/webdiff/static/js/components.jsx
@@ -56,6 +56,7 @@ var makeRoot = function(filePairs, initiallySelectedIndex) {
     render: function() {
       var idx = this.getIndex(),
           filePair = this.props.filePairs[idx];
+      document.title = "Diff: " + filePairDisplayName(filePair) + " ("+ filePair.type + ")";
 
       return (
         <div>


### PR DESCRIPTION
Fixes the TypeError issue in #126 and the real problem which was Python3 compatibility with doing a webdiff of pull requests (e.g. `webdiff #113`).

I ran the nose tests on Python2 and Python3, but I was unable to get the javascript tests to work. We probably need to update from using bower for them. Maybe there are other issue with the javascript tests too. I really know very little about javascript.