### PR TITLE
Add host option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,10 @@
 Two-column web-based git difftool.
 
 <p align="center">
-  <a href="https://pypi.org/project/webdiff/" target="_blank">
-    <img alt="PyPI - Version" src="https://img.shields.io/pypi/v/webdiff">
-  </a>
-  <a href="https://dl.circleci.com/status-badge/redirect/gh/danvk/webdiff/tree/master" target="_blank">
-    <img alt="CircleCI 📝" src="https://dl.circleci.com/status-badge/img/gh/danvk/webdiff/tree/master.svg?style=svg">
-  </a>
-  <a href="https://github.com/danvk/webdiff/blob/master/LICENSE" target="_blank">
-    <img alt="License: Apache2 📝" src="https://img.shields.io/github/license/danvk/webdiff">
-  </a>
-  <a href="https://github.com/sponsors/danvk" target="_blank">
-    <img alt="Sponsor: On GitHub 💸" src="https://img.shields.io/badge/sponsor-on_github_💸-21bb42.svg" />
-  </a>
+  <a href="https://pypi.org/project/webdiff/" target="_blank"><img alt="PyPI - Version" src="https://img.shields.io/pypi/v/webdiff" /></a>
+  <a href="https://dl.circleci.com/status-badge/redirect/gh/danvk/webdiff/tree/master" target="_blank"><img alt="CircleCI 📝" src="https://dl.circleci.com/status-badge/img/gh/danvk/webdiff/tree/master.svg?style=svg" /></a>
+  <a href="https://github.com/danvk/webdiff/blob/master/LICENSE" target="_blank"><img alt="License: Apache2 📝" src="https://img.shields.io/github/license/danvk/webdiff" /></a>
+  <a href="https://github.com/sponsors/danvk" target="_blank"><img alt="Sponsor: On GitHub 💸" src="https://img.shields.io/badge/sponsor-on_github_💸-21bb42.svg" /></a>
 </p>
 
 Features include:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ Options are:
 | Setting        | Default       | Notes  |
 | -------------- | ------------- | ------ |
 | webdiff.theme  | googlecode    | Syntax highlighting theme (see [themes] directory). |
-| webdiff.port   | -1            | Port on which to serve webdiff. Default is random open port. This can be overridden with `--port`. |
+| webdiff.port   | -1            | Port on which to serve webdiff. Default is random open port. This can be overridden with the `--port` command line flag or the `WEBDIFF_PORT` environment variable. |
+| webdiff.host   | localhost     | Host name on which to serve the webdiff UI. Use `0.0.0.0` to serve publicly. The special value `<hostname>` uses your computer's network name. This can be overridden with the `--host` command line flag or the `WEBDIFF_HOST` environment variable. |
 | webdiff.maxDiffWidth | 100 | Maximum length of lines in the diff display. After this width, lines will wrap. |
 | webdiff.unified | 8 | Lines of context to display by default (`git diff -U`) |
 | webdiff.extraDirDiffArgs | "" | Any extra arguments to pass to `git diff` when diffing directories. |

--- a/webdiff/app.py
+++ b/webdiff/app.py
@@ -340,8 +340,8 @@ def run():
         sys.stderr.write('GitConfig: %s\n' % GIT_CONFIG)
 
     PORT = pick_a_port(parsed_args, WEBDIFF_CONFIG)
-
-    if app.config.get('USE_HOSTNAME'):
+    HOSTNAME = os.environ.get('WEBDIFF_HOST') or WEBDIFF_CONFIG['host']
+    if HOSTNAME == '<hostname>':
         _hostname = platform.node()
         # platform.node will return empty string if it can't find the hostname
         if not _hostname:

--- a/webdiff/app.py
+++ b/webdiff/app.py
@@ -278,7 +278,7 @@ def open_browser():
     global PORT
     global HOSTNAME
     global GIT_CONFIG
-    if (not 'NO_OPEN_BROWSER' in app.config) and GIT_CONFIG['webdiff']['openBrowser']:
+    if GIT_CONFIG['webdiff']['openBrowser']:
         if is_hot_reload():
             log.debug('Skipping browser open on reload')
         else:
@@ -294,8 +294,9 @@ def pick_a_port(args, webdiff_config):
     if 'port' in args:
         return args['port']
 
-    if os.environ.get('WEBDIFF_PORT'):
-        return int(os.environ.get('WEBDIFF_PORT'))
+    env_port = os.environ.get('WEBDIFF_PORT')
+    if env_port:
+        return int(env_port)
 
     # gitconfig
     if webdiff_config['port'] != -1:
@@ -340,7 +341,11 @@ def run():
         sys.stderr.write('GitConfig: %s\n' % GIT_CONFIG)
 
     PORT = pick_a_port(parsed_args, WEBDIFF_CONFIG)
-    HOSTNAME = os.environ.get('WEBDIFF_HOST') or WEBDIFF_CONFIG['host']
+    HOSTNAME = (
+        parsed_args.get('host')
+        or os.environ.get('WEBDIFF_HOST')
+        or WEBDIFF_CONFIG['host']
+    )
     if HOSTNAME == '<hostname>':
         _hostname = platform.node()
         # platform.node will return empty string if it can't find the hostname

--- a/webdiff/argparser.py
+++ b/webdiff/argparser.py
@@ -31,6 +31,11 @@ def parse(args, version=None):
     """Returns {port, dirs: [], files: [], pr: {owner, repo, number}}."""
     parser = argparse.ArgumentParser(description='Run webdiff.', usage=USAGE)
     parser.add_argument('--version', action='version', version='webdiff %s' % version)
+    parser.add_argument(
+        '--host', type=str,
+        help="Host name on which to serve webdiff UI. Default is localhost.",
+        default=None
+    )
     parser.add_argument('--port', '-p', type=int, help="Port to run webdiff on.", default=-1)
     parser.add_argument(
         'dirs', type=str, nargs='+', help="Directories to diff, or a github pull request URL."
@@ -41,6 +46,8 @@ def parse(args, version=None):
     out = {}
     if args.port != -1:
         out['port'] = args.port
+    if args.host:
+        out['host'] = args.host
 
     if len(args.dirs) > 2:
         raise UsageError('You must specify two files/dirs (got %d)' % len(args.dirs))

--- a/webdiff/options.py
+++ b/webdiff/options.py
@@ -10,6 +10,7 @@ DEFAULTS = {
         "extraFileDiffArgs": "",
         "openBrowser": True,
         "port": -1,  # random
+        "host": "localhost",
         "maxDiffWidth": 100,
         "theme": "googlecode",
         "maxLinesForSyntax": 10_000,


### PR DESCRIPTION
Fixes #123
Fixes #156

This removes the old `USE_HOSTNAME` configuration setting from #113 in favor of a more powerful set of "host" options:

    git config webdiff.host 0.0.0.0

This tells webdiff to serve its UI on `0.0.0.0` rather than `localhost` for the current repo (or globally with `git config --global`).

Alternatively you can use an environment variable:

    WEBDIFF_HOST=127.0.0.1 webdiff dir1 dir2

or a command-line flag:

    webdiff --host '<hostname>' dir1 dir2

The special value `<hostname>` determines the computer's network name and uses that. This replaces the old behavior of `USE_HOSTNAME`. On my laptop, the last command serves traffic on `http://danvk-macbook-air.local:6001/`.

@NikolasOliveira FYI the upcoming 1.0.0 release of webdiff will require a slightly different syntax for `USE_HOSTNAME`.