### PR TITLE
fix bugs with fetching GitHub PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can pass all the same arguments that you would to `git diff`, e.g.
 You can also use `webdiff` to view GitHub pull requests:
 
     webdiff https://github.com/owner/repo/pull/123
-    webdiff #123  # if you're in a git repo with a github remote
+    webdiff '#123'  # if you're in a git repo with a github remote
 
 This will download the files relevant to the Pull Request and run `webdiff`.
 

--- a/webdiff/argparser.py
+++ b/webdiff/argparser.py
@@ -62,8 +62,8 @@ def parse(args, version=None):
         # Or perhaps something simpler like '#292'?
         m = re.match(PULL_REQUEST_NUM_RE, args.dirs[0])
         if m:
-            num = int(m.group(1))
-            owner, repo, num = github_fetcher.get_pr_repo(num)
+            num = m.group(1)
+            owner, repo, num = github_fetcher.get_pr_repo(int(num))
 
         if not owner:
             raise UsageError(


### PR DESCRIPTION
The `webdiff #123` form documented in the README wasn't working.