### PR TITLE
Simplify kill logic

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -639,4 +639,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "042a571b2ad91deb947e51c70f19c33d39942d239f4e36e3752958729f9ad847"
+content-hash = "8241d97f5f913054308727cfdf015d4d97eebec891010eda1bc57a1d65e3f309"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ include = ["webdiff/static/js/file_diff.js"]
 python = "^3.10"
 binaryornot = "*"
 pillow = "*"
-requests = "*"
 PyGithub = "==1.55"
 unidiff = "==0.7.4"
 

--- a/webdiff/app.py
+++ b/webdiff/app.py
@@ -233,10 +233,8 @@ class CustomHTTPRequestHandler(BaseHTTPRequestHandler):
 
         def shutdown():
             if LAST_REQUEST_MS <= last_ms:  # subsequent requests abort shutdown
-                logging.debug('No subsequent requests. Goodbye!')
-                threading.Thread(target=self.server.shutdown).start()
-            else:
-                logging.debug('Received another request; canceling shutdown.')
+                # logging.debug('No subsequent requests. Goodbye!\n')
+                threading.Thread(target=self.server.shutdown, daemon=True).start()
 
         logging.debug('Received request to shut down; waiting 500ms for subsequent requests...')
         threading.Timer(0.5, shutdown).start()

--- a/webdiff/app.py
+++ b/webdiff/app.py
@@ -233,8 +233,11 @@ class CustomHTTPRequestHandler(BaseHTTPRequestHandler):
 
         def shutdown():
             if LAST_REQUEST_MS <= last_ms:  # subsequent requests abort shutdown
-                # logging.debug('No subsequent requests. Goodbye!\n')
+                # See https://stackoverflow.com/a/19040484/388951
+                # and https://stackoverflow.com/q/4330111/388951
                 threading.Thread(target=self.server.shutdown, daemon=True).start()
+            else:
+                logging.debug('Received subsequent request; canceling shutdown')
 
         logging.debug('Received request to shut down; waiting 500ms for subsequent requests...')
         threading.Timer(0.5, shutdown).start()
@@ -265,10 +268,6 @@ class CustomHTTPRequestHandler(BaseHTTPRequestHandler):
 def note_request_time():
     global LAST_REQUEST_MS
     LAST_REQUEST_MS = time.time() * 1000
-
-
-# See https://stackoverflow.com/a/69812984/388951
-exiting = False
 
 
 def open_browser():

--- a/webdiff/app.py
+++ b/webdiff/app.py
@@ -12,7 +12,6 @@ import mimetypes
 import os
 import re
 import platform
-import requests
 import socket
 import sys
 import threading
@@ -115,8 +114,6 @@ class CustomHTTPRequestHandler(BaseHTTPRequestHandler):
         elif m := re.match(r'/diff/(?P<idx>\d+)', path):
             payload = json.loads(post_data.decode('utf-8'))
             self.handle_diff_ops(int(m['idx']), payload)
-        elif path == '/seriouslykill':
-            self.handle_seriouslykill()
         elif path == '/kill':
             self.handle_kill()
         else:
@@ -231,21 +228,17 @@ class CustomHTTPRequestHandler(BaseHTTPRequestHandler):
         ]
         self.send_response_with_json(200, diff_ops)
 
-    def handle_seriouslykill(self):
-        self.send_response(200)
-        self.send_header('Content-Type', 'text/plain')
-        self.end_headers()
-        self.wfile.write(b'Shutting down...')
-        threading.Thread(target=self.server.shutdown).start()
-
     def handle_kill(self):
-        global LAST_REQUEST_MS
         last_ms = LAST_REQUEST_MS
 
         def shutdown():
             if LAST_REQUEST_MS <= last_ms:  # subsequent requests abort shutdown
-                requests.post('http://localhost:%d/seriouslykill' % PORT)
+                logging.debug('No subsequent requests. Goodbye!')
+                threading.Thread(target=self.server.shutdown).start()
+            else:
+                logging.debug('Received another request; canceling shutdown.')
 
+        logging.debug('Received request to shut down; waiting 500ms for subsequent requests...')
         threading.Timer(0.5, shutdown).start()
         self.send_response(200)
         self.send_header('Content-Type', 'text/plain')


### PR DESCRIPTION
See #133, this PR drops `requests`

Now that I'm not using Flask, the shutdown logic can be simplified. Instead of `/kill` hitting `/seriouslykill`, I just need a `/kill` endpoint. Adding `daemon=True` to the shutdown thread seemed to make the server shut down more reliably in testing, so I hope that was the root issue of the flakiness I've seen over the years.

This doesn't fully eliminate the `requests` dependency because pygithub still depends on it:

```
$ poetry show requests
 name         : requests
 version      : 2.32.3
 description  : Python HTTP for Humans.

dependencies
 - certifi >=2017.4.17
 - charset-normalizer >=2,<4
 - idna >=2.5,<4
 - urllib3 >=1.21.1,<3

required by
 - pygithub >=2.14.0
```