### PR TITLE
Diffhunk selection and keyboard shortcuts for next/prev

### DIFF
--- a/ts/codediff/DiffRow.tsx
+++ b/ts/codediff/DiffRow.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import {addCharacterDiffs} from './char-diffs';
+import {DiffRange} from './codes';
+import {scrollIntoViewIfNeeded} from './dom-utils';
+
+// TODO: factor out a {text, html} type
+interface DiffRowProps {
+  type: DiffRange['type'];
+  beforeLineNum: number | null;
+  afterLineNum: number | null;
+  beforeText: string | undefined;
+  beforeHTML?: string;
+  afterText: string | undefined;
+  afterHTML?: string;
+  isSelected: boolean;
+}
+
+function escapeHtml(unsafe: string) {
+  return unsafe
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
+
+const makeCodeTd = (type: string, text: string | undefined, html: string | undefined) => {
+  if (text === undefined) {
+    return {text: '', html: '', className: 'empty code'};
+  }
+  if (html === undefined) {
+    html = escapeHtml(text);
+  }
+  text = text.replaceAll('\t', '\u00a0\u00a0\u00a0\u00a0');
+  html = html.replaceAll('\t', '\u00a0\u00a0\u00a0\u00a0');
+  const className = 'code ' + type;
+  return {className, html, text};
+};
+
+export function DiffRow(props: DiffRowProps) {
+  const {beforeLineNum, afterLineNum, type, isSelected} = props;
+  const cells = [
+    makeCodeTd(type, props.beforeText, props.beforeHTML),
+    makeCodeTd(type, props.afterText, props.afterHTML),
+  ];
+  let [beforeHtml, afterHtml] = [cells[0].html, cells[1].html];
+  if (type === 'replace') {
+    [beforeHtml, afterHtml] = addCharacterDiffs(
+      cells[0].text,
+      cells[0].html,
+      cells[1].text,
+      cells[1].html,
+    );
+  }
+  const rowRef = React.useRef<HTMLTableRowElement>(null);
+  React.useEffect(() => {
+    if (isSelected && rowRef.current) {
+      scrollIntoViewIfNeeded(rowRef.current);
+    }
+  }, [isSelected]);
+  return (
+    <tr ref={rowRef} className={isSelected ? 'selected' : undefined}>
+      <td className="line-no">{beforeLineNum ?? ''}</td>
+      <td
+        className={cells[0].className + ' before'}
+        dangerouslySetInnerHTML={{__html: beforeHtml}}></td>
+      <td
+        className={cells[1].className + ' after'}
+        dangerouslySetInnerHTML={{__html: afterHtml}}></td>
+      <td className="line-no">{afterLineNum ?? ''}</td>
+    </tr>
+  );
+}

--- a/ts/codediff/SkipRow.tsx
+++ b/ts/codediff/SkipRow.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import {scrollIntoViewIfNeeded} from './dom-utils';
+
+export interface SkipRange {
+  beforeStartLine: number;
+  afterStartLine: number;
+  numRows: number;
+}
+
+export interface SkipRowProps extends SkipRange {
+  header: string | null;
+  expandLines: number;
+  /** positive num = expand down, negative num = expand up */
+  onShowMore: (existing: SkipRange, num: number) => void;
+  isSelected: boolean;
+}
+
+export function SkipRow(props: SkipRowProps) {
+  const {expandLines, header, onShowMore, isSelected, ...range} = props;
+  const {numRows} = range;
+  const showAll = (e: React.MouseEvent) => {
+    e.preventDefault();
+    onShowMore(range, numRows);
+  };
+  const arrows =
+    numRows <= expandLines ? (
+      <span className="skip" title={`show ${numRows} skipped lines`} onClick={showAll}>
+        ↕
+      </span>
+    ) : (
+      <>
+        <span
+          className="skip expand-up"
+          title={`show ${expandLines} more lines above`}
+          onClick={() => {
+            onShowMore(range, -expandLines);
+          }}>
+          ↥
+        </span>
+        <span
+          className="skip expand-down"
+          title={`show ${expandLines} more lines below`}
+          onClick={() => {
+            onShowMore(range, expandLines);
+          }}>
+          ↧
+        </span>
+      </>
+    );
+  const showMore = (
+    <a href="#" onClick={showAll}>
+      Show {numRows} more lines
+    </a>
+  );
+  const headerHTML = header ? <span className="hunk-header">${header}</span> : '';
+
+  const rowRef = React.useRef<HTMLTableRowElement>(null);
+  React.useEffect(() => {
+    if (isSelected && rowRef.current) {
+      scrollIntoViewIfNeeded(rowRef.current);
+    }
+  }, [isSelected]);
+  return (
+    <tr ref={rowRef} className={'skip-row' + (isSelected ? ` selected` : '')}>
+      <td colSpan={4} className="skip code">
+        <span className="arrows-left">{arrows}</span>
+        {showMore} {headerHTML}
+        <span className="arrows-right">{arrows}</span>
+      </td>
+    </tr>
+  );
+}

--- a/ts/codediff/codediff.tsx
+++ b/ts/codediff/codediff.tsx
@@ -197,7 +197,7 @@ const CodeDiffView = React.memo((props: CodeDiffViewProps) => {
     const numRows = Math.max(numBeforeRows, numAfterRows);
     const beforeStartLine = before[0];
     const afterStartLine = after[0];
-    const trClassName = afterStartLine === selectedLine ? 'selected' : undefined;
+    const isSelected = afterStartLine === selectedLine;
     if (type == 'skip') {
       diffRows.push(
         <SkipRow
@@ -208,7 +208,7 @@ const CodeDiffView = React.memo((props: CodeDiffViewProps) => {
           header={range.header ?? null}
           expandLines={expandLines}
           onShowMore={handleShowMore}
-          trClassName={trClassName}
+          isSelected={isSelected}
         />,
       );
     } else {
@@ -233,7 +233,7 @@ const CodeDiffView = React.memo((props: CodeDiffViewProps) => {
             beforeHTML={beforeHTML}
             afterText={afterText}
             afterHTML={afterHTML}
-            trClassName={j === 0 ? trClassName : undefined}
+            isSelected={j === 0 && isSelected}
           />,
         );
       }
@@ -290,11 +290,11 @@ export interface SkipRowProps extends SkipRange {
   expandLines: number;
   /** positive num = expand down, negative num = expand up */
   onShowMore: (existing: SkipRange, num: number) => void;
-  trClassName?: string;
+  isSelected: boolean;
 }
 
 function SkipRow(props: SkipRowProps) {
-  const {expandLines, header, onShowMore, trClassName, ...range} = props;
+  const {expandLines, header, onShowMore, isSelected, ...range} = props;
   const {numRows} = range;
   const showAll = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -331,8 +331,15 @@ function SkipRow(props: SkipRowProps) {
     </a>
   );
   const headerHTML = header ? <span className="hunk-header">${header}</span> : '';
+
+  const rowRef = React.useRef<HTMLTableRowElement>(null);
+  React.useEffect(() => {
+    if (isSelected && rowRef.current) {
+      (rowRef.current as any).scrollIntoViewIfNeeded();
+    }
+  }, [isSelected]);
   return (
-    <tr className={'skip-row' + (trClassName ? ` ${trClassName}` : '')}>
+    <tr ref={rowRef} className={'skip-row' + (isSelected ? ` selected` : '')}>
       <td colSpan={4} className="skip code">
         <span className="arrows-left">{arrows}</span>
         {showMore} {headerHTML}
@@ -351,7 +358,7 @@ interface DiffRowProps {
   beforeHTML?: string;
   afterText: string | undefined;
   afterHTML?: string;
-  trClassName?: string;
+  isSelected: boolean;
 }
 
 function escapeHtml(unsafe: string) {
@@ -377,7 +384,7 @@ const makeCodeTd = (type: string, text: string | undefined, html: string | undef
 };
 
 function DiffRow(props: DiffRowProps) {
-  const {beforeLineNum, afterLineNum, type} = props;
+  const {beforeLineNum, afterLineNum, type, isSelected} = props;
   const cells = [
     makeCodeTd(type, props.beforeText, props.beforeHTML),
     makeCodeTd(type, props.afterText, props.afterHTML),
@@ -391,8 +398,14 @@ function DiffRow(props: DiffRowProps) {
       cells[1].html,
     );
   }
+  const rowRef = React.useRef<HTMLTableRowElement>(null);
+  React.useEffect(() => {
+    if (isSelected && rowRef.current) {
+      (rowRef.current as any).scrollIntoViewIfNeeded();
+    }
+  }, [isSelected]);
   return (
-    <tr className={props.trClassName}>
+    <tr ref={rowRef} className={isSelected ? 'selected' : undefined}>
       <td className="line-no">{beforeLineNum ?? ''}</td>
       <td
         className={cells[0].className + ' before'}

--- a/ts/codediff/codediff.tsx
+++ b/ts/codediff/codediff.tsx
@@ -279,6 +279,10 @@ const CodeDiffView = React.memo((props: CodeDiffViewProps) => {
   );
 });
 
+interface WebkitHTMLTableRowElement extends HTMLTableRowElement {
+  scrollIntoViewIfNeeded?: () => void;
+}
+
 interface SkipRange {
   beforeStartLine: number;
   afterStartLine: number;
@@ -335,7 +339,8 @@ function SkipRow(props: SkipRowProps) {
   const rowRef = React.useRef<HTMLTableRowElement>(null);
   React.useEffect(() => {
     if (isSelected && rowRef.current) {
-      (rowRef.current as any).scrollIntoViewIfNeeded();
+      const tr = rowRef.current as WebkitHTMLTableRowElement;
+      tr.scrollIntoViewIfNeeded?.() ?? tr.scrollIntoView({block: 'nearest'});
     }
   }, [isSelected]);
   return (
@@ -401,7 +406,8 @@ function DiffRow(props: DiffRowProps) {
   const rowRef = React.useRef<HTMLTableRowElement>(null);
   React.useEffect(() => {
     if (isSelected && rowRef.current) {
-      (rowRef.current as any).scrollIntoViewIfNeeded();
+      const tr = rowRef.current as WebkitHTMLTableRowElement;
+      tr.scrollIntoViewIfNeeded?.() ?? tr.scrollIntoView({block: 'nearest'});
     }
   }, [isSelected]);
   return (

--- a/ts/codediff/dom-utils.ts
+++ b/ts/codediff/dom-utils.ts
@@ -76,3 +76,13 @@ export function copyOnlyMatching(e: ClipboardEvent, selector: string) {
   e.clipboardData?.setData('text', text);
   e.preventDefault();
 }
+
+interface WebkitElement extends Element {
+  scrollIntoViewIfNeeded?: () => void;
+}
+
+/** scrollIntoViewIfNeeded has nicer behavior than the web standard, but is non-standard. */
+export function scrollIntoViewIfNeeded(el: Element) {
+  const wkEl = el as WebkitElement;
+  wkEl.scrollIntoViewIfNeeded?.() ?? wkEl.scrollIntoView({block: 'nearest'});
+}

--- a/webdiff/static/css/style.css
+++ b/webdiff/static/css/style.css
@@ -16,7 +16,7 @@ div#thediff {
 
 /* It's not possible to set a border without shifting the row */
 tr.selected {
-  box-shadow: 0px -2px 0px 0px yellow;
+  box-shadow: 0px -2px 0px 0px rgb(216,225,253);
   z-index: 1;
   position: relative;
 }

--- a/webdiff/static/css/style.css
+++ b/webdiff/static/css/style.css
@@ -14,6 +14,13 @@ div#thediff {
     font-size: 13px;
 }
 
+/* It's not possible to set a border without shifting the row */
+tr.selected {
+  box-shadow: 0px -2px 0px 0px hotpink;
+  z-index: 1;
+  position: relative;
+}
+
 /* This is overridden in JS based on your .gitconfig */
 td.code {
   width: 101ch;  /* per-side max line length */

--- a/webdiff/static/css/style.css
+++ b/webdiff/static/css/style.css
@@ -16,8 +16,14 @@ div#thediff {
 
 /* It's not possible to set a border without shifting the row */
 tr.selected {
-  box-shadow: 0px -2px 0px 0px hotpink;
+  box-shadow: 0px -2px 0px 0px yellow;
   z-index: 1;
+  position: relative;
+}
+
+/* keeps the header on top of the selection line and cell */
+.diff thead {
+  z-index: 2;
   position: relative;
 }
 


### PR DESCRIPTION
Fixes #13 

The CSS wound up being a little weird and there's definitely some missing features/bugs. But the crucial thing is that bouncing on "n" scrolls through the diff for you.

<img width="1484" alt="image" src="https://github.com/danvk/webdiff/assets/98301/f2b10af3-6caa-4814-8d3a-76a6e8f7e075">

Selection color is cribbed from screenshots of Critique in this article: https://read.engineerscodex.com/p/how-google-takes-the-pain-out-of
