### PR TITLE
Keyboard shortcuts UI

### DIFF
--- a/ts/DiffOptions.tsx
+++ b/ts/DiffOptions.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {DiffAlgorithm, DiffOptions, encodeDiffOptions} from './diff-options';
 import {PageCover} from './codediff/PageCover';
+import {isLegitKeypress} from './file_diff';
 
 export interface Props {
   options: Partial<DiffOptions>;
@@ -68,6 +69,21 @@ export function DiffOptionsControl(props: Props) {
   const changeDiffAlgorithm: React.ChangeEventHandler<HTMLSelectElement> = e => {
     setOptions({...options, diffAlgorithm: e.currentTarget.value as DiffAlgorithm});
   };
+
+  React.useEffect(() => {
+    const handleKeydown = (e: KeyboardEvent) => {
+      if (!isLegitKeypress(e)) return;
+      if (e.code == 'KeyW') {
+        setOptions({...options, ignoreAllSpace: !options.ignoreAllSpace});
+      } else if (e.code == 'KeyB') {
+        setOptions({...options, ignoreSpaceChange: !options.ignoreSpaceChange});
+      }
+    };
+    document.addEventListener('keydown', handleKeydown);
+    return () => {
+      document.removeEventListener('keydown', handleKeydown);
+    };
+  }, [options, setOptions]);
 
   const diffOptsStr = encodeDiffOptions(options).join(' ');
 

--- a/ts/DiffOptions.tsx
+++ b/ts/DiffOptions.tsx
@@ -6,6 +6,8 @@ import {PageCover} from './codediff/PageCover';
 export interface Props {
   options: Partial<DiffOptions>;
   setOptions: (newOptions: Partial<DiffOptions>) => void;
+  isVisible: boolean;
+  setIsVisible: (isVisible: boolean) => void;
 }
 
 const gearStyle: React.CSSProperties = {
@@ -46,11 +48,10 @@ const popupStyle: React.CSSProperties = {
 };
 
 export function DiffOptionsControl(props: Props) {
-  const {options, setOptions} = props;
-  const [isPopupVisible, setIsPopupVisible] = React.useState(false);
+  const {options, setOptions, isVisible, setIsVisible} = props;
 
   const togglePopup = () => {
-    setIsPopupVisible(oldVal => !oldVal);
+    setIsVisible(!isVisible);
   };
   const toggleIgnoreAllSpace = () => {
     setOptions({...options, ignoreAllSpace: !options.ignoreAllSpace});
@@ -75,7 +76,7 @@ export function DiffOptionsControl(props: Props) {
       <button style={gearStyle} onClick={togglePopup}>
         ⚙
       </button>
-      {isPopupVisible ? (
+      {isVisible ? (
         <>
           <PageCover onClick={togglePopup} />
           <div style={popupStyle}>

--- a/ts/DiffOptions.tsx
+++ b/ts/DiffOptions.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {DiffAlgorithm, DiffOptions, encodeDiffOptions} from './diff-options';
+import {PageCover} from './codediff/PageCover';
 
 export interface Props {
   options: Partial<DiffOptions>;
@@ -28,18 +29,9 @@ const closeButtonStyle: React.CSSProperties = {
   cursor: 'pointer',
 };
 
-const pageCoverStyle: React.CSSProperties = {
-  position: 'absolute',
-  zIndex: 1,
-  left: 0,
-  top: 0,
-  right: 0,
-  bottom: 0,
-};
-
 const popupStyle: React.CSSProperties = {
   position: 'fixed',
-  zIndex: 2,
+  zIndex: 3,
   right: 8,
   border: '1px solid #ddd',
   borderRadius: 4,
@@ -85,7 +77,7 @@ export function DiffOptionsControl(props: Props) {
       </button>
       {isPopupVisible ? (
         <>
-          <div style={pageCoverStyle} onClick={togglePopup}></div>
+          <PageCover onClick={togglePopup} />
           <div style={popupStyle}>
             <button style={closeButtonStyle} onClick={togglePopup}>
               ✕

--- a/ts/DiffView.tsx
+++ b/ts/DiffView.tsx
@@ -12,8 +12,8 @@ export interface Props {
   imageDiffMode: ImageDiffMode;
   pdiffMode: PerceptualDiffMode;
   diffOptions: Partial<DiffOptions>;
-  changeImageDiffModeHandler: (mode: ImageDiffMode) => void;
-  changePDiffMode: (pdiffMode: PerceptualDiffMode) => void;
+  changeImageDiffMode: (mode: ImageDiffMode) => void;
+  changePDiffMode: React.Dispatch<React.SetStateAction<PerceptualDiffMode>>;
   changeDiffOptions: (options: Partial<DiffOptions>) => void;
 }
 

--- a/ts/ImageDiffModeSelector.tsx
+++ b/ts/ImageDiffModeSelector.tsx
@@ -10,7 +10,7 @@ export type ImageDiffMode = (typeof IMAGE_DIFF_MODES)[number];
 export interface Props {
   filePair: FilePair;
   imageDiffMode: ImageDiffMode;
-  changeImageDiffModeHandler: (imageDiffMode: ImageDiffMode) => void;
+  changeImageDiffMode: (imageDiffMode: ImageDiffMode) => void;
 }
 
 /** A widget to toggle between image diff modes (blink or side-by-side). */
@@ -27,7 +27,7 @@ export function ImageDiffModeSelector(props: Props) {
         <a
           href="#"
           onClick={() => {
-            props.changeImageDiffModeHandler(val);
+            props.changeImageDiffMode(val);
           }}>
           {inner}
         </a>

--- a/ts/Root.tsx
+++ b/ts/Root.tsx
@@ -58,6 +58,8 @@ export function Root(props: Props) {
         setPDiffMode(mode => PDIFF_MODES[(PDIFF_MODES.indexOf(mode) + 1) % 3]);
       } else if (e.code === 'Slash' && e.shiftKey) {
         setShowKeyboardHelp(val => !val);
+      } else if (e.code === 'Escape') {
+        setShowKeyboardHelp(false);
       }
     };
     document.addEventListener('keydown', handleKeydown);

--- a/ts/Root.tsx
+++ b/ts/Root.tsx
@@ -23,6 +23,7 @@ export function Root(props: Props) {
   const [imageDiffMode, setImageDiffMode] = React.useState<ImageDiffMode>('side-by-side');
   const [diffOptions, setDiffOptions] = React.useState<Partial<DiffOptions>>({});
   const [showKeyboardHelp, setShowKeyboardHelp] = React.useState(false);
+  const [showOptions, setShowOptions] = React.useState(false);
 
   const history = useHistory();
   const selectIndex = React.useCallback(
@@ -60,6 +61,8 @@ export function Root(props: Props) {
         setShowKeyboardHelp(val => !val);
       } else if (e.code === 'Escape') {
         setShowKeyboardHelp(false);
+      } else if (e.code === 'Period') {
+        setShowOptions(val => !val);
       }
     };
     document.addEventListener('keydown', handleKeydown);
@@ -70,7 +73,12 @@ export function Root(props: Props) {
 
   return (
     <div>
-      <DiffOptionsControl options={diffOptions} setOptions={setDiffOptions} />
+      <DiffOptionsControl
+        options={diffOptions}
+        setOptions={setDiffOptions}
+        isVisible={showOptions}
+        setIsVisible={setShowOptions}
+      />
       <FileSelector selectedFileIndex={idx} filePairs={pairs} fileChangeHandler={selectIndex} />
       {showKeyboardHelp ? (
         <KeyboardShortcuts

--- a/ts/Root.tsx
+++ b/ts/Root.tsx
@@ -8,6 +8,7 @@ import {isLegitKeypress} from './file_diff';
 import {ImageDiffMode} from './ImageDiffModeSelector';
 import {filePairDisplayName} from './utils';
 import {DiffOptionsControl} from './DiffOptions';
+import {KeyboardShortcuts} from './codediff/KeyboardShortcuts';
 
 declare const pairs: FilePair[];
 declare const initialIdx: number;
@@ -21,6 +22,7 @@ export function Root(props: Props) {
   const [pdiffMode, setPDiffMode] = React.useState<PerceptualDiffMode>('off');
   const [imageDiffMode, setImageDiffMode] = React.useState<ImageDiffMode>('side-by-side');
   const [diffOptions, setDiffOptions] = React.useState<Partial<DiffOptions>>({});
+  const [showKeyboardHelp, setShowKeyboardHelp] = React.useState(false);
 
   const history = useHistory();
   const selectIndex = React.useCallback(
@@ -53,19 +55,28 @@ export function Root(props: Props) {
       } else if (e.code == 'KeyB') {
         setImageDiffMode('blink');
       } else if (e.code == 'KeyP') {
-        setPDiffMode(PDIFF_MODES[(PDIFF_MODES.indexOf(pdiffMode) + 1) % 3]);
+        setPDiffMode(mode => PDIFF_MODES[(PDIFF_MODES.indexOf(mode) + 1) % 3]);
+      } else if (e.code === 'Slash' && e.shiftKey) {
+        setShowKeyboardHelp(val => !val);
       }
     };
     document.addEventListener('keydown', handleKeydown);
     return () => {
       document.removeEventListener('keydown', handleKeydown);
     };
-  }, [idx, pdiffMode, selectIndex, setImageDiffMode, setPDiffMode]);
+  }, [idx, selectIndex]);
 
   return (
     <div>
       <DiffOptionsControl options={diffOptions} setOptions={setDiffOptions} />
       <FileSelector selectedFileIndex={idx} filePairs={pairs} fileChangeHandler={selectIndex} />
+      {showKeyboardHelp ? (
+        <KeyboardShortcuts
+          onClose={() => {
+            setShowKeyboardHelp(false);
+          }}
+        />
+      ) : null}
       <DiffView
         key={`diff-${idx}`}
         thinFilePair={filePair}

--- a/ts/Root.tsx
+++ b/ts/Root.tsx
@@ -15,8 +15,6 @@ declare const initialIdx: number;
 
 type Props = RouteComponentProps<{index?: string}>;
 
-const PDIFF_MODES: PerceptualDiffMode[] = ['off', 'bbox', 'pixels'];
-
 // Webdiff application root.
 export function Root(props: Props) {
   const [pdiffMode, setPDiffMode] = React.useState<PerceptualDiffMode>('off');
@@ -51,12 +49,6 @@ export function Root(props: Props) {
         if (idx < pairs.length - 1) {
           selectIndex(idx + 1);
         }
-      } else if (e.code == 'KeyS') {
-        setImageDiffMode('side-by-side');
-      } else if (e.code == 'KeyB') {
-        setImageDiffMode('blink');
-      } else if (e.code == 'KeyP') {
-        setPDiffMode(mode => PDIFF_MODES[(PDIFF_MODES.indexOf(mode) + 1) % 3]);
       } else if (e.code === 'Slash' && e.shiftKey) {
         setShowKeyboardHelp(val => !val);
       } else if (e.code === 'Escape') {
@@ -93,7 +85,7 @@ export function Root(props: Props) {
         imageDiffMode={imageDiffMode}
         pdiffMode={pdiffMode}
         diffOptions={diffOptions}
-        changeImageDiffModeHandler={setImageDiffMode}
+        changeImageDiffMode={setImageDiffMode}
         changePDiffMode={setPDiffMode}
         changeDiffOptions={setDiffOptions}
       />

--- a/ts/codediff/KeyboardShortcuts.tsx
+++ b/ts/codediff/KeyboardShortcuts.tsx
@@ -72,7 +72,7 @@ export function KeyboardShortcuts(props: KeyboardShortcutsProps) {
               <kbd>?</kbd> Show this panel
             </li>
           </ul>
-          <p className="header">Image Diff Keyboard Shortcuts</p>
+          <p className="header">Image Diff</p>
           <ul>
             <li>
               <kbd>s</kbd> Side-by-Side (image diff)
@@ -82,6 +82,15 @@ export function KeyboardShortcuts(props: KeyboardShortcutsProps) {
             </li>
             <li>
               <kbd>p</kbd> Cycle perceptual diff mode (image diff)
+            </li>
+          </ul>
+          <p className="header">Diff Options</p>
+          <ul>
+            <li>
+              <kbd>w</kbd> Toggle <code>-w</code> (<code>--ignore-all-space</code>) option
+            </li>
+            <li>
+              <kbd>b</kbd> Toggle <code>-b</code> (<code>--ignore-space-change</code>) option
             </li>
           </ul>
         </div>

--- a/ts/codediff/KeyboardShortcuts.tsx
+++ b/ts/codediff/KeyboardShortcuts.tsx
@@ -16,11 +16,6 @@ const closeButtonStyle: React.CSSProperties = {
 
 const popupStyle: React.CSSProperties = {
   zIndex: 3,
-  /*
-  position: 'fixed',
-  left: '50%',
-  top: '50%',
-  */
   position: 'absolute',
   border: '1px solid #ddd',
   borderRadius: 4,
@@ -29,7 +24,6 @@ const popupStyle: React.CSSProperties = {
   paddingLeft: 18,
   paddingRight: 18,
   background: 'white',
-  // fontSize: '90%',
   userSelect: 'none',
   boxShadow: '0px 0px 8px 0px rgba(0,0,0,0.5)',
   fontFamily: 'sans-serif',
@@ -70,6 +64,9 @@ export function KeyboardShortcuts(props: KeyboardShortcutsProps) {
             </li>
             <li>
               <kbd>p</kbd> Previous Diffhunk
+            </li>
+            <li>
+              <kbd>.</kbd> Show diff options
             </li>
             <li>
               <kbd>?</kbd> Show this panel

--- a/ts/codediff/KeyboardShortcuts.tsx
+++ b/ts/codediff/KeyboardShortcuts.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import {PageCover} from './PageCover';
+
+export interface KeyboardShortcutsProps {
+  onClose: () => void;
+}
+
+const closeButtonStyle: React.CSSProperties = {
+  position: 'absolute',
+  right: 0,
+  marginTop: -8,
+  border: 0,
+  background: 'transparent',
+  cursor: 'pointer',
+};
+
+const popupStyle: React.CSSProperties = {
+  zIndex: 3,
+  /*
+  position: 'fixed',
+  left: '50%',
+  top: '50%',
+  */
+  position: 'absolute',
+  border: '1px solid #ddd',
+  borderRadius: 4,
+  paddingTop: 12,
+  paddingBottom: 0,
+  paddingLeft: 18,
+  paddingRight: 18,
+  background: 'white',
+  // fontSize: '90%',
+  userSelect: 'none',
+  boxShadow: '0px 0px 8px 0px rgba(0,0,0,0.5)',
+  fontFamily: 'sans-serif',
+};
+
+const popupContainerStyle: React.CSSProperties = {
+  zIndex: 3,
+  display: 'flex' /* establish flex container */,
+  flexDirection: 'column' /* make main axis vertical */,
+  justifyContent: 'center' /* center items vertically, in this case */,
+  alignItems: 'center' /* center items horizontally, in this case */,
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+};
+
+export function KeyboardShortcuts(props: KeyboardShortcutsProps) {
+  return (
+    <>
+      <PageCover onClick={props.onClose} />
+      <div style={popupContainerStyle}>
+        <div style={popupStyle} className="keyboard-shortcuts">
+          <button style={closeButtonStyle} onClick={props.onClose}>
+            ✕
+          </button>
+          <p className="header">Webdiff Keyboard Shortcuts</p>
+          <ul>
+            <li>
+              <kbd>j</kbd> Next File
+            </li>
+            <li>
+              <kbd>k</kbd> Previous File
+            </li>
+            <li>
+              <kbd>n</kbd> Next Diffhunk
+            </li>
+            <li>
+              <kbd>p</kbd> Previous Diffhunk
+            </li>
+            <li>
+              <kbd>?</kbd> Show this panel
+            </li>
+          </ul>
+          <p className="header">Image Diff Keyboard Shortcuts</p>
+          <ul>
+            <li>
+              <kbd>s</kbd> Side-by-Side (image diff)
+            </li>
+            <li>
+              <kbd>b</kbd> Blink (image diff)
+            </li>
+            <li>
+              <kbd>p</kbd> Cycle perceptual diff mode (image diff)
+            </li>
+          </ul>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/ts/codediff/PageCover.tsx
+++ b/ts/codediff/PageCover.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const pageCoverStyle: React.CSSProperties = {
+  position: 'absolute',
+  zIndex: 3,
+  left: 0,
+  top: 0,
+  right: 0,
+  bottom: 0,
+};
+
+export interface PageCoverProps {
+  onClick: () => void;
+}
+
+export function PageCover(props: PageCoverProps) {
+  return <div style={pageCoverStyle} onClick={props.onClick}></div>;
+}

--- a/webdiff/static/css/style.css
+++ b/webdiff/static/css/style.css
@@ -189,3 +189,30 @@ table .side-a, table .side-b {
 .magick {
   font-style: italic;
 }
+
+/* Cribbed from GitHub */
+kbd {
+  display: inline-block;
+  padding: 3px 5px;
+  line-height: 10px;
+  color: rgb(31, 35, 40);
+  vertical-align: middle;
+  background-color: rgb(246, 248, 250);
+  border: solid 1px rgba(175, 184, 193, 0.2);
+  border-radius: 6px;
+  box-shadow: rgba(175, 184, 193, 0.2) 0px -1px 0px 0px inset;
+}
+
+.keyboard-shortcuts { font-size: 80%; }
+
+.keyboard-shortcuts .header {
+  font-weight: bold;
+}
+
+.keyboard-shortcuts ul {
+  padding-left: 0;  /* 1em; */
+}
+.keyboard-shortcuts li {
+  list-style-type: none;
+  margin-bottom: 2px;
+}


### PR DESCRIPTION
Fixes #87 

Also added some new shortcuts for opening the diff options UI and toggling the `-b` and `-w` options.

Here's what it looks like:

<img width="540" alt="image" src="https://github.com/danvk/webdiff/assets/98301/16dca7c0-ef32-4359-9dc2-1ccbe1df08d9">
