### PR TITLE
Autofix: Unable to diff two file descriptors

### DIFF
--- a/webdiff/diff.py
+++ b/webdiff/diff.py
@@ -33,10 +33,8 @@ def get_thin_dict(diff):
 
 
 def fast_num_lines(path: str) -> int:
-    # See https://stackoverflow.com/q/9629179/388951 for the idea to use a Unix command.
-    # Unfortunately `wc -l` ignores the last line if there is no trailing newline. So
-    # instead, see https://stackoverflow.com/a/38870057/388951
-    return int(subprocess.check_output(['grep', '-c', '', path]))
+    with open(path, 'rb') as f:
+        return sum(1 for _ in f)
 
 
 def get_diff_ops(diff: LocalFileDiff, git_diff_args=None) -> List[Code]:


### PR DESCRIPTION
I have identified the issue with the `webdiff <(cmd1) <(cmd2)` command not working as expected. The problem lies in the `fast_num_lines` function in the `webdiff/diff.py` file. The current implementation uses `grep` to count the lines, which doesn't work with process substitution. I've modified the function to use Python's built-in file handling, which should work with both regular files and process substitution. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission