### PR TITLE
Detach process

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ To iterate on the PyPI package, run:
 
     pip3 uninstall webdiff
     poetry build
-    pip3 install dist/webdiff-?.?.?.tar.gz
+    pip3 install dist/webdiff-(latest).tar.gz
 
 To publish to pypitest:
 
@@ -154,6 +154,8 @@ To publish to pypitest:
 And to the real pypi:
 
     poetry publish
+
+You can publish pre-release versions to pypi by adding "bN" to the version number.
 
 See [pypirc][] and [poetry][] docs for details on setting up tokens for pypi.
 
@@ -184,7 +186,10 @@ When you run `git webdiff (args)`, it runs:
 
 This tells `git` to set up two directories and invoke `webdiff leftdir rightdir`.
 
-There's one complication involving symlinks. `git difftool -d` may fill one of the sides (typically the right) with symlinks. This is faster than copying files, but unfortunately `git diff --no-index` does not resolve these symlinks. To make this work, if a directory contains symlinks, webdiff makes a copy of it before diffing. For file diffs, it resolves the symlink before passing it to `git diff --no-index`. The upshot is that you can run `git webdiff`, edit a file, reload the browser window and see the changes.
+There are two wrinkles here:
+
+- `git difftool -d` may fill one of the sides (typically the right) with symlinks. This is faster than copying files, but unfortunately `git diff --no-index` does not resolve these symlinks. To make this work, if a directory contains symlinks, webdiff makes a copy of it before diffing. For file diffs, it resolves the symlink before passing it to `git diff --no-index`. The upshot is that you can run `git webdiff`, edit a file, reload the browser window and see the changes.
+- `git difftool` cleans up its temporary directories when the main webdiff process terminates. Since webdiff detaches to give you back your terminal, it has to make another copy of the directories (this time without resolving symlinks) to make sure they're still there for the child process.
 
 [pypirc]: https://packaging.python.org/specifications/pypirc/
 [Homebrew]: https://brew.sh/

--- a/webdiff/app.py
+++ b/webdiff/app.py
@@ -276,12 +276,6 @@ def pick_a_port(args, webdiff_config):
 
 
 def run_http():
-    sys.stderr.write(
-        """Serving diffs on http://%s:%s
-Close the browser tab or hit Ctrl-C when you're done.
-"""
-        % (HOSTNAME, PORT)
-    )
     threading.Timer(0.1, open_browser).start()
 
     web.run_app(app, host=HOSTNAME, port=PORT)
@@ -294,7 +288,7 @@ def maybe_shutdown():
 
     def shutdown():
         if LAST_REQUEST_MS <= last_ms:  # subsequent requests abort shutdown
-            sys.stderr.write('Shutting down...\n')
+            logging.debug('Shutting down...')
             signal.raise_signal(signal.SIGINT)
         else:
             logging.debug('Received subsequent request; shutdown aborted.')
@@ -340,6 +334,15 @@ def run():
     run_in_process = os.environ.get('WEBDIFF_RUN_IN_PROCESS') or (
         DEBUG and not DEBUG_DETACH
     )
+
+    if not os.environ.get('WEBDIFF_LOGGED_MESSAGE'):
+        # Printing this in the main process gives you your prompt back more cleanly.
+        print(
+            """Serving diffs on http://%s:%s
+Close the browser tab when you're done."""
+            % (HOSTNAME, PORT)
+        )
+        os.environ['WEBDIFF_LOGGED_MESSAGE'] = '1'
 
     if run_in_process:
         run_http()

--- a/webdiff/app.py
+++ b/webdiff/app.py
@@ -278,7 +278,7 @@ def pick_a_port(args, webdiff_config):
 def run_http():
     threading.Timer(0.1, open_browser).start()
 
-    web.run_app(app, host=HOSTNAME, port=PORT)
+    web.run_app(app, host=HOSTNAME, port=PORT, print=print if DEBUG else None)
     logging.debug('http server shut down')
 
 

--- a/webdiff/app.py
+++ b/webdiff/app.py
@@ -277,7 +277,6 @@ def pick_a_port(args, webdiff_config):
 
 def run_http():
     threading.Timer(0.1, open_browser).start()
-
     web.run_app(app, host=HOSTNAME, port=PORT, print=print if DEBUG else None)
     logging.debug('http server shut down')
 
@@ -339,7 +338,7 @@ def run():
         # Printing this in the main process gives you your prompt back more cleanly.
         print(
             """Serving diffs on http://%s:%s
-Close the browser tab when you're done."""
+Close the browser tab when you're done to terminate the process."""
             % (HOSTNAME, PORT)
         )
         os.environ['WEBDIFF_LOGGED_MESSAGE'] = '1'

--- a/webdiff/app.py
+++ b/webdiff/app.py
@@ -13,6 +13,7 @@ import os
 import platform
 import signal
 import socket
+import subprocess
 import sys
 import threading
 import time
@@ -334,7 +335,12 @@ def run():
         else:
             HOSTNAME = _hostname
 
-    run_http()
+    if os.environ.get('WEBDIFF_RUN_IN_PROCESS') or DEBUG:
+        run_http()
+    else:
+        os.environ['WEBDIFF_RUN_IN_PROCESS'] = '1'
+        os.environ['WEBDIFF_PORT'] = str(PORT)
+        subprocess.Popen((sys.executable, *sys.argv))
 
 
 if __name__ == '__main__':

--- a/webdiff/app.py
+++ b/webdiff/app.py
@@ -358,7 +358,7 @@ Close the browser tab when you're done to terminate the process."""
             os.environ['WEBDIFF_DIR_A'] = copied_dir_a
             os.environ['WEBDIFF_DIR_B'] = copied_dir_b
             logging.debug(f'Copied {dir_a} -> {copied_dir_a} before detaching')
-            logging.debug(f'Copied {dir_b} -> {copied_dir_a} before detaching')
+            logging.debug(f'Copied {dir_b} -> {copied_dir_b} before detaching')
         subprocess.Popen((sys.executable, *sys.argv))
 
 

--- a/webdiff/argparser.py
+++ b/webdiff/argparser.py
@@ -4,9 +4,7 @@ import argparse
 import os
 import re
 
-from webdiff import dirdiff
-from webdiff import githubdiff
-from webdiff import github_fetcher
+from webdiff import dirdiff, github_fetcher, githubdiff
 from webdiff.localfilediff import LocalFileDiff
 
 
@@ -81,6 +79,12 @@ def parse(args, version=None):
 
     else:
         a, b = args.dirs
+        if os.environ.get('WEBDIFF_DIR_A') and os.environ.get('WEBDIFF_DIR_A'):
+            # This happens when you run "git webdiff" and we have to make a copy of
+            # the temp directories before we detach and git difftool cleans them up.
+            a = os.environ.get('WEBDIFF_DIR_A')
+            b = os.environ.get('WEBDIFF_DIR_B')
+
         for x in (a, b):
             if not os.path.exists(x):
                 raise UsageError('"%s" does not exist' % x)

--- a/webdiff/argparser.py
+++ b/webdiff/argparser.py
@@ -79,7 +79,7 @@ def parse(args, version=None):
 
     else:
         a, b = args.dirs
-        if os.environ.get('WEBDIFF_DIR_A') and os.environ.get('WEBDIFF_DIR_A'):
+        if os.environ.get('WEBDIFF_DIR_A') and os.environ.get('WEBDIFF_DIR_B'):
             # This happens when you run "git webdiff" and we have to make a copy of
             # the temp directories before we detach and git difftool cleans them up.
             a = os.environ.get('WEBDIFF_DIR_A')

--- a/webdiff/dirdiff.py
+++ b/webdiff/dirdiff.py
@@ -1,7 +1,7 @@
 """Compute the diff between two directories on local disk."""
 
-import os
 import logging
+import os
 import shutil
 import subprocess
 import tempfile
@@ -27,7 +27,7 @@ def contains_symlinks(dir: str):
     return False
 
 
-def make_resolved_dir(dir: str) -> str:
+def make_resolved_dir(dir: str, follow_symlinks=False) -> str:
     # TODO: clean up this directory
     temp_dir = tempfile.mkdtemp(prefix='webdiff')
     for root, dirs, files in os.walk(dir):
@@ -38,7 +38,7 @@ def make_resolved_dir(dir: str) -> str:
             src_file = os.path.join(root, file_name)
             rel = os.path.relpath(src_file, dir)
             dst_file = os.path.join(temp_dir, rel)
-            shutil.copy(src_file, dst_file, follow_symlinks=True)
+            shutil.copy(src_file, dst_file, follow_symlinks=follow_symlinks)
     return temp_dir
 
 
@@ -49,11 +49,11 @@ def gitdiff(a_dir: str, b_dir: str, webdiff_config):
         cmd += ' ' + extra_args
     a_dir_nosym = a_dir
     if contains_symlinks(a_dir):
-        a_dir_nosym = make_resolved_dir(a_dir)
+        a_dir_nosym = make_resolved_dir(a_dir, follow_symlinks=True)
         logging.debug(f'Inlined symlinks in left directory {a_dir} -> {a_dir_nosym}')
     b_dir_nosym = b_dir
     if contains_symlinks(b_dir):
-        b_dir_nosym = make_resolved_dir(b_dir)
+        b_dir_nosym = make_resolved_dir(b_dir, follow_symlinks=True)
         logging.debug(f'Inlined symlinks in right directory {b_dir} -> {b_dir_nosym}')
     args = cmd.split(' ') + [a_dir_nosym, b_dir_nosym]
     logging.debug('Running git command: %s', args)

--- a/webdiff/github_fetcher.py
+++ b/webdiff/github_fetcher.py
@@ -6,11 +6,11 @@ This will create symlinks or clone git repos as needed.
 # Use this PR for testing to see all four types of change at once:
 # https://github.com/danvk/test-repo/pull/2/
 
-from collections import OrderedDict
 import os
 import re
 import subprocess
 import sys
+from collections import OrderedDict
 
 from github import Github, UnknownObjectException
 
@@ -138,7 +138,7 @@ def _get_github_remotes():
 
 # e.g. 'origin	git@github.com:danvk/expandable-image-grid.git (push)'
 ssh_push_re = re.compile(
-    '(?P<name>[^\s]+)\s+((?P<user>[^@]+)@)?(?P<host>[^:]+)(?::(?P<path>[^\s]+))?\s\(push\)'
+    r'(?P<name>[^\s]+)\s+((?P<user>[^@]+)@)?(?P<host>[^:]+)(?::(?P<path>[^\s]+))?\s\(push\)'
 )
 
 # e.g. 'origin	https://github.com/danvk/git-helpers.git (push)'

--- a/webdiff/gitwebdiff.py
+++ b/webdiff/gitwebdiff.py
@@ -21,6 +21,7 @@ def run(argv=sys.argv):
             if not os.environ.get('DEBUG')
             else os.path.join(os.path.curdir, 'test.sh')
         )
+        os.environ['WEBDIFF_FROM_GIT_DIFFTOOL'] = '1'
         subprocess.call(f'git difftool -d -x {cmd}'.split(' ') + argv[1:])
     except KeyboardInterrupt:
         # Don't raise an exception to the user when sigint is received

--- a/webdiff/toy.py
+++ b/webdiff/toy.py
@@ -1,8 +1,7 @@
 # Trying to make a server that detaches
-
-
 import os
-import threading
+import subprocess
+import sys
 import time
 
 
@@ -14,8 +13,11 @@ def run():
 
 
 def main():
-    server_thread = threading.Thread(target=run)
-    server_thread.start()
+    if len(sys.argv) > 1:
+        run()
+    else:
+        subprocess.Popen((sys.executable, sys.argv[0], 'SUB'))
+        print('terminating parent process')
 
 
 if __name__ == '__main__':

--- a/webdiff/toy.py
+++ b/webdiff/toy.py
@@ -7,16 +7,18 @@ import time
 
 def run():
     print('running server...')
+    print(f'{sys.argv=}')
     print(f'{os.getpid()=}')
     time.sleep(3)
     print('shutting down.')
 
 
 def main():
-    if len(sys.argv) > 1:
+    if os.environ.get('SUB'):
         run()
     else:
-        subprocess.Popen((sys.executable, sys.argv[0], 'SUB'))
+        os.environ['SUB'] = '1'
+        subprocess.Popen((sys.executable, *sys.argv))
         print('terminating parent process')
 
 

--- a/webdiff/toy.py
+++ b/webdiff/toy.py
@@ -1,0 +1,22 @@
+# Trying to make a server that detaches
+
+
+import os
+import threading
+import time
+
+
+def run():
+    print('running server...')
+    print(f'{os.getpid()=}')
+    time.sleep(3)
+    print('shutting down.')
+
+
+def main():
+    server_thread = threading.Thread(target=run)
+    server_thread.start()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Fixes #89 

This has been a long-standing pet peeve of mine. If you have a few `git webdiff` tabs live, you lose most of your terminals! Thanks to #223, webdiff reliably terminates when you close the tab. This means it's safe to detach.

There are two complications here:

- To "detach," we have to re-run the same command in a subprocess (see [this question](https://stackoverflow.com/a/33144867/388951)). I distinguish the parent/child processes through an environment variable.
- `git difftool` cleans up after itself when the parent process terminates (makes sense!). This means that the child process tries to diff non-existent directories. To make that work, we have to make a copy of the directories before detaching. Fortunately, this can be a shallow copy. We don't need to resolve symlinks.

This seems to work great, but I'll have to try it out locally for a bit to feel confident.